### PR TITLE
chore(deploy): prepare Render demo startup

### DIFF
--- a/accessledger/settings.py
+++ b/accessledger/settings.py
@@ -99,10 +99,10 @@ DATABASES = {
     }
 }
 
-CSRF_TRUSTED_ORIGINS = [
-    "https://web-production-0ea6.up.railway.app",
-]
-
+CSRF_TRUSTED_ORIGINS = os.environ.get(
+    "CSRF_TRUSTED_ORIGINS",
+    "https://*.onrender.com",
+).split(",")
 
 # Password validation
 # https://docs.djangoproject.com/en/5.2/ref/settings/#auth-password-validators

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,9 +4,13 @@ echo "Collecting static files..."
 python manage.py collectstatic --noinput --clear
 echo "Aplicando migraciones..."
 python manage.py migrate --noinput
+echo "Creando roles y datos demo..."
+python manage.py bootstrap_roles
+python manage.py seed_data
 echo "Arrancando servidor..."
 if [ "$DEBUG" = "True" ]; then
-    exec python manage.py runserver 0.0.0.0:8000
+  exec python manage.py runserver 0.0.0.0:8000
 else
-    exec gunicorn accessledger.wsgi --bind 0.0.0.0:${PORT:-8080} --log-file -
+  exec gunicorn accessledger.wsgi --bind 0.0.0.0:${PORT:-8080} --log-file -
 fi
+


### PR DESCRIPTION
Closes #10

## Summary
- Make CSRF trusted origins configurable for Render.
- Run role/bootstrap demo seed commands after migrations for fresh Render databases.

## Changes
| File | Change |
|------|--------|
| `accessledger/settings.py` | Reads `CSRF_TRUSTED_ORIGINS` from env with Render wildcard fallback. |
| `entrypoint.sh` | Runs `bootstrap_roles` and `seed_data` after migrations before starting Gunicorn. |

## Test plan
- [x] Render Docker deployment previously built and ran migrations successfully.
- [ ] GitHub checks / Render redeploy after merge.