### PR TITLE
fix(deploy): avoid blocking Render startup

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,9 +4,10 @@ echo "Collecting static files..."
 python manage.py collectstatic --noinput --clear
 echo "Aplicando migraciones..."
 python manage.py migrate --noinput
-echo "Creando roles y datos demo..."
-python manage.py bootstrap_roles
-python manage.py seed_data
+echo "Demo roles/data se crean en background (no bloquea el arranque)..."
+(
+  python manage.py bootstrap_roles && python manage.py seed_data || echo "WARNING: demo seeding falló — ignorando"
+) &
 echo "Arrancando servidor..."
 if [ "$DEBUG" = "True" ]; then
   exec python manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
Closes #12

## Summary
- Run demo role/data seeding in the background after migrations.
- Keep Gunicorn startup unblocked so Render can detect the HTTP port quickly.

## Changes
| File | Change |
|------|--------|
| `entrypoint.sh` | Moves demo seeding into a non-blocking background subshell. |

## Test plan
- [x] Verified diff keeps collectstatic/migrate before server startup.
- [ ] Verify Render redeploy reaches Gunicorn and serves `/login/`.