### PR TITLE
fix(users): enable management search

### DIFF
--- a/core/static/core/js/user_management.js
+++ b/core/static/core/js/user_management.js
@@ -1,3 +1,38 @@
+// ── Búsqueda en tabla de usuarios ──────────────────────────────────────────
+(() => {
+  const q = document.getElementById("q");
+  const table = document.getElementById("usersTable");
+  const pill = document.getElementById("countPill");
+
+  if (!table || !pill) return;
+  if (!q) return;
+
+  const rows = Array.from(table.querySelectorAll("tbody tr.row"));
+
+  const setCount = (n) => {
+    pill.textContent = `${n} usuario${n === 1 ? "" : "s"}`;
+  };
+
+  const filter = (value) => {
+    const term = value.trim().toLowerCase();
+    let visible = 0;
+
+    rows.forEach((tr) => {
+      const text = tr.innerText.toLowerCase();
+      const show = term === "" || text.includes(term);
+      tr.style.display = show ? "" : "none";
+      if (show) visible += 1;
+    });
+
+    setCount(visible);
+  };
+
+  // Initial count
+  if (rows.length > 0) setCount(rows.length);
+
+  q.addEventListener("input", (e) => filter(e.target.value));
+})();
+
 // Obtiene el CSRF token de las cookies
 function getCsrfToken() {
   const match = document.cookie.match(/csrftoken=([^;]+)/);


### PR DESCRIPTION
Closes #14

## Summary
- Add client-side filtering for the user management table.
- Update the count pill as users are filtered.

## Changes
| File | Change |
|------|--------|
| `core/static/core/js/user_management.js` | Adds a focused search handler for `#usersTable`. |

## Test plan
- [x] Verified implementation targets `#usersTable` without changing resource search.
- [ ] Manually verify `/users/manage/` search after deploy.

## Notes
Existing pytest suite currently has unrelated PostgreSQL connectivity errors in this environment.