### PR TITLE
fix(users): redirect direct form routes

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -299,10 +299,7 @@ def user_create(request):
     elif is_ajax:
         return HttpResponseNotAllowed(["POST"])
     else:
-        form = UserForm()
-    return render(request, "core/user_create.html", {
-        "form": form
-    })
+        return redirect("user_management")
 
 @login_required
 @admin_required
@@ -358,11 +355,7 @@ def user_update(request, pk):
     elif is_ajax:
         return HttpResponseNotAllowed(["POST"])
     else:
-        form = UserForm()
-    return render(request, "core/user_update.html", {
-        "user": user,
-        "form": form
-    })
+        return redirect("user_management")
 
 @login_required
 @admin_required

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -127,7 +127,6 @@ class TestGrantRevokeView:
         response = admin_client.post(f"/grants/{grant.pk}/revoke")
         assert response.status_code == 302
 
-
 @pytest.mark.django_db
 class TestAuditLogView:
     def test_redirects_if_not_logged_in(self, client):
@@ -145,3 +144,56 @@ class TestAuditLogView:
     def test_admin_can_access(self, admin_client):
         response = admin_client.get("/audit_log/")
         assert response.status_code == 200
+
+@pytest.mark.django_db
+class TestUserCreateView:
+    def test_non_ajax_get_redirects_to_user_management(self, admin_client):
+        """Direct GET should redirect to user_management instead of 500."""
+        response = admin_client.get("/users/create/")
+        assert response.status_code == 302
+        assert response.url == "/users/manage/"
+
+    def test_non_admin_cannot_access(self, viewer_client):
+        response = viewer_client.get("/users/create/")
+        assert response.status_code == 403
+
+    def test_ajax_get_returns_405(self, admin_client):
+        response = admin_client.get(
+            "/users/create/", HTTP_X_REQUESTED_WITH="XMLHttpRequest"
+        )
+        assert response.status_code == 405
+
+    def test_ajax_post_creates_user(self, admin_client):
+        group = Group.objects.create(name="test-group")
+        response = admin_client.post("/users/create/", data={
+            "username": "newuser",
+            "email": "new@test.com",
+            "first_name": "New",
+            "last_name": "User",
+            "password": "testpass123",
+            "role": group.pk,
+        }, HTTP_X_REQUESTED_WITH="XMLHttpRequest")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+
+@pytest.mark.django_db
+class TestUserUpdateView:
+    def test_non_ajax_get_redirects_to_user_management(self, admin_client):
+        """Direct GET should redirect to user_management instead of 500."""
+        user = User.objects.create_user(username="targetuser", password="pass")
+        response = admin_client.get(f"/users/{user.pk}/edit/")
+        assert response.status_code == 302
+        assert response.url == "/users/manage/"
+
+    def test_non_admin_cannot_access(self, viewer_client):
+        user = User.objects.create_user(username="targetuser", password="pass")
+        response = viewer_client.get(f"/users/{user.pk}/edit/")
+        assert response.status_code == 403
+
+    def test_ajax_get_returns_405(self, admin_client):
+        user = User.objects.create_user(username="targetuser", password="pass")
+        response = admin_client.get(
+            f"/users/{user.pk}/edit/", HTTP_X_REQUESTED_WITH="XMLHttpRequest"
+        )
+        assert response.status_code == 405


### PR DESCRIPTION
Closes #16

## Summary
- Redirect direct user create/edit GET requests to user management instead of rendering missing templates.
- Add focused view tests for direct route fallbacks and AJAX handling.

## Changes
| File | Change |
|------|--------|
| `core/views.py` | Redirects non-AJAX user create/edit fallbacks to `user_management`. |
| `tests/test_views.py` | Adds coverage for user create/edit route behavior. |

## Test plan
- [x] `pytest --collect-only` succeeded in sub-agent verification.
- [ ] Full pytest run blocked locally by PostgreSQL connection at `127.0.0.1:5434`.

## Notes
Existing test execution requires the project PostgreSQL test database to be running.