### PR TITLE
chore: read test db credentials from env

### DIFF
--- a/accessledger/settings_test.py
+++ b/accessledger/settings_test.py
@@ -6,10 +6,10 @@ DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
         "NAME": "accessledger",
-        "USER": "danidev_dj",
-        "PASSWORD": "12345_dj",
-        "HOST": "127.0.0.1",
-        "PORT": os.getenv("POSTGRES_HOST_PORT", "5434"),
+        "USER": os.getenv("POSTGRES_USER", "danidev_dj"),
+        "PASSWORD": os.getenv("POSTGRES_PASSWORD", ""),
+        "HOST": os.getenv("POSTGRES_HOST", "127.0.0.1"),
+        "PORT": os.getenv("POSTGRES_PORT", "5432"),
     }
 }
 


### PR DESCRIPTION
Closes #20

## Summary
- Move test database user, password, host, and port configuration to environment variables.
- Remove the hardcoded test database password from source.
- Align test database port configuration with POSTGRES_PORT used elsewhere.

## Changes
| File | Change |
|------|--------|
| `accessledger/settings_test.py` | Reads test DB connection values from env vars and removes hardcoded password |

## Test Plan
- [x] `python3 -m py_compile accessledger/settings_test.py`
- [x] Fresh diff review approved before commit/PR

## PR Type
- [x] Maintenance/tooling

## Checklist
- [x] Linked an approved issue
- [x] Conventional commit format
- [x] No hardcoded test database password
