### PR TITLE
fix: require password on user creation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,9 @@ POSTGRES_HOST_PORT=5434
 SECRET_KEY = 
 DEBUG = 
 ALLOWED_HOSTS = 
+# Test environment example (.env.test)
+# POSTGRES_DB=accessledger
+# POSTGRES_USER=postgres
+# POSTGRES_PASSWORD=
+# POSTGRES_HOST=db
+# POSTGRES_PORT=5432

--- a/README.es.md
+++ b/README.es.md
@@ -32,6 +32,7 @@
 - [Comandos de gestión](#-comandos-de-gestión)
 - [Seguridad](#-seguridad)
 - [Interfaz de usuario](#-interfaz-de-usuario)
+- [Tests](#-tests)
 - [Despliegue](#-despliegue)
 - [Hoja de ruta](#-hoja-de-ruta)
 
@@ -259,6 +260,23 @@ cp .env.example .env
 > [!CAUTION]
 > Nunca incluya el archivo `.env` en el control de versiones. El `.gitignore` ya está configurado para excluirlo.
 
+### Entorno de tests
+
+Los tests pueden usar un archivo `.env.test` separado para que la configuración de la aplicación y la configuración de pruebas no se pisen entre sí. Esto es especialmente útil al ejecutar tests dentro de Docker, donde el host de la base de datos es `db` y el puerto interno de PostgreSQL es `5432`.
+
+Crear `.env.test` localmente:
+
+```env
+POSTGRES_DB=accessledger
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=
+POSTGRES_HOST=db
+POSTGRES_PORT=5432
+```
+
+> [!NOTE]
+> `POSTGRES_HOST_PORT` solo sirve para conectarse desde la máquina host hacia Docker, por ejemplo `localhost:5434`. Los contenedores deben conectarse a PostgreSQL mediante `db:5432`.
+
 ---
 
 ## ⚙️ Comandos de gestión
@@ -333,19 +351,36 @@ AccessLedger cuenta con una interfaz de usuario con **tema oscuro** personalizad
 
 ## 🧪 Tests
 
-El proyecto incluye una suite de 21 tests automatizados construida con pytest-django, cubriendo tres capas:
+El proyecto incluye una suite de 22 tests automatizados construida con pytest-django, cubriendo tres capas:
 
 | Capa | Archivo | Tests |
 |------|---------|-------|
 | Validación de formularios | `tests/test_forms.py` | 7 |
 | Lógica de modelos y señales | `tests/test_models.py` | 4 |
-| Permisos de vistas (RBAC) | `tests/test_views.py` | 10 |
+| Permisos de vistas y flujos de usuario | `tests/test_views.py` | 11 |
 
 Los tests verifican casos borde en formularios (nombres duplicados, rangos de fechas inválidos), los métodos `__str__` de los modelos, la creación automática de `Profile` mediante señales de Django, y que cada rol (`viewer`, `editor`, `admin`) solo puede acceder a las vistas que sus permisos permiten.
 
-Para ejecutar los tests localmente necesitas PostgreSQL corriendo y un archivo `accessledger/settings_test.py` configurado con las credenciales de tu base de datos local:
+### Recomendado: ejecutar tests dentro de Docker
+
+Docker Compose permite que el proceso de tests acceda al servicio PostgreSQL como `db:5432`, coincidiendo con el ejemplo de `.env.test` anterior:
+
 ```bash
-pytest -v
+docker compose run --rm web pytest -v
+```
+
+Ejecutar solo los tests de creación de usuarios:
+
+```bash
+docker compose run --rm web pytest tests/test_views.py -k "UserCreate"
+```
+
+### Alternativa con Python local
+
+Si ejecutás pytest directamente desde tu máquina host, recordá que `db` es un hostname exclusivo de Docker. Sobrescribí el host y el puerto de la base de datos para tu entorno local:
+
+```bash
+POSTGRES_HOST=127.0.0.1 POSTGRES_PORT=5434 pytest -v
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 - [Management Commands](#-management-commands)
 - [Security](#-security)
 - [UI Overview](#-ui-overview)
+- [Testing](#-testing)
 - [Deployment](#-deployment)
 - [Roadmap](#-roadmap)
 
@@ -259,6 +260,23 @@ cp .env.example .env
 > [!CAUTION]
 > Never commit your `.env` file to version control. The `.gitignore` is already configured to exclude it.
 
+### Test environment
+
+Tests can use a separate `.env.test` file so the application config and test config do not fight each other. This is especially useful when running tests inside Docker, where the database host is `db` and the internal PostgreSQL port is `5432`.
+
+Create `.env.test` locally:
+
+```env
+POSTGRES_DB=accessledger
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=
+POSTGRES_HOST=db
+POSTGRES_PORT=5432
+```
+
+> [!NOTE]
+> `POSTGRES_HOST_PORT` is only for connecting from your host machine to Docker, for example `localhost:5434`. Containers should connect to PostgreSQL through `db:5432`.
+
 ---
 
 ## ⚙️ Management Commands
@@ -333,19 +351,36 @@ AccessLedger features a custom **dark theme UI** built entirely with native web 
 
 ## 🧪 Testing
 
-The project includes a suite of 21 automated tests built with pytest-django, covering three layers:
+The project includes a suite of 22 automated tests built with pytest-django, covering three layers:
 
 | Layer | File | Tests |
 |-------|------|-------|
 | Form validation | `tests/test_forms.py` | 7 |
 | Model logic & signals | `tests/test_models.py` | 4 |
-| View permissions (RBAC) | `tests/test_views.py` | 10 |
+| View permissions and user flows | `tests/test_views.py` | 11 |
 
 Tests verify form edge cases (duplicate names, invalid date ranges), model `__str__` methods, the auto-creation of `Profile` via Django signals, and that each role (`viewer`, `editor`, `admin`) can only access the views their permissions allow.
 
-To run the test suite locally, you need PostgreSQL running and a `accessledger/settings_test.py` configured with your local database credentials:
+### Recommended: run tests inside Docker
+
+Docker Compose gives the test process access to the PostgreSQL service as `db:5432`, matching the `.env.test` example above:
+
 ```bash
-pytest -v
+docker compose run --rm web pytest -v
+```
+
+Run only the user creation tests:
+
+```bash
+docker compose run --rm web pytest tests/test_views.py -k "UserCreate"
+```
+
+### Local Python alternative
+
+If you run pytest directly from your host machine, remember that `db` is a Docker-only hostname. Override the database host and port for your local environment:
+
+```bash
+POSTGRES_HOST=127.0.0.1 POSTGRES_PORT=5434 pytest -v
 ```
 
 ---

--- a/accessledger/settings_test.py
+++ b/accessledger/settings_test.py
@@ -1,6 +1,9 @@
 import os
 
 from .settings import *
+from dotenv import load_dotenv
+
+load_dotenv(BASE_DIR / ".env.test", override=True)
 
 DATABASES = {
     "default": {

--- a/core/forms.py
+++ b/core/forms.py
@@ -4,18 +4,22 @@ from typing import Optional
 from django import forms
 from .models import AccessGrant, Resource
 from django.contrib.auth.models import User, Group
+
+
 class AccessGrantForm(forms.ModelForm):
     class Meta:
         model = AccessGrant
         fields = ["user", "access_level", "start_at", "end_at", "notes"]
-    
+
     def clean(self):
         cleaned_data = super().clean()
         start_at = cleaned_data.get("start_at")
         end_at = cleaned_data.get("end_at")
         if start_at and end_at:
             if end_at <= start_at:
-                raise forms.ValidationError("Error no puede ser anterior la fecha fin a la de fecha de inicio")
+                raise forms.ValidationError(
+                    "Error no puede ser anterior la fecha fin a la de fecha de inicio"
+                )
         return cleaned_data
 
 
@@ -28,6 +32,11 @@ class ResourceForm(forms.ModelForm):
 class UserForm(forms.ModelForm):
     role = forms.ModelChoiceField(queryset=Group.objects.all())
     password = forms.CharField(required=False, widget=forms.PasswordInput)
+
     class Meta:
         model = User
         fields = ["username", "email", "first_name", "last_name"]
+
+
+class UserCreateForm(UserForm):
+    password = forms.CharField(required=True, widget=forms.PasswordInput)

--- a/core/views.py
+++ b/core/views.py
@@ -2,7 +2,7 @@ from django.shortcuts import redirect, render, get_object_or_404
 from django.contrib.auth.decorators import permission_required, login_required
 from django.http import JsonResponse, HttpResponseNotAllowed
 from core.decorators import admin_required
-from core.forms import AccessGrantForm, ResourceForm, UserForm
+from core.forms import AccessGrantForm, ResourceForm, UserForm, UserCreateForm
 from .models import AccessGrant, Resource, Profile, AuditLog
 from django.contrib.auth.models import User, Group
 from django.contrib.auth.views import PasswordChangeView
@@ -14,28 +14,37 @@ from .utils import log_action
 @permission_required("core.view_resource", raise_exception=True)
 def resource_list(request):
     resources = Resource.objects.all().order_by("name")
-    return render(request, "core/resource_list.html", {"resources": resources, "form": ResourceForm()})
+    return render(
+        request,
+        "core/resource_list.html",
+        {"resources": resources, "form": ResourceForm()},
+    )
+
 
 @login_required
 @permission_required("core.view_resource", raise_exception=True)
 def resource_detail(request, pk):
     resource = get_object_or_404(Resource, pk=pk)
     grants = (
-        AccessGrant.objects
-        .filter(resource=resource)
+        AccessGrant.objects.filter(resource=resource)
         .select_related("user")
         .order_by("status", "-end_at")
     )
-    return render(request, "core/resource_detail.html", {
-        "resource": resource,
-        "grants": grants,
-    })
+    return render(
+        request,
+        "core/resource_detail.html",
+        {
+            "resource": resource,
+            "grants": grants,
+        },
+    )
+
 
 @login_required
 @permission_required("core.add_resource", raise_exception=True)
 def resource_create(request):
     is_ajax = request.headers.get("X-Requested-With") == "XMLHttpRequest"
-    
+
     if request.method == "POST":
         form = ResourceForm(request.POST)
         if form.is_valid():
@@ -47,17 +56,22 @@ def resource_create(request):
                 action=AuditLog.Action.RESOURCE_CREATED,
                 obj=resource,
                 before=None,
-                after={"name": resource.name, "resource_type": resource.resource_type}
+                after={"name": resource.name, "resource_type": resource.resource_type},
             )
-            return JsonResponse({"success": True}) if is_ajax else redirect("resource_list")
+            return (
+                JsonResponse({"success": True})
+                if is_ajax
+                else redirect("resource_list")
+            )
         elif is_ajax:
             return JsonResponse({"success": False, "errors": form.errors})
     elif is_ajax:
         return HttpResponseNotAllowed(["POST"])
     else:
         form = ResourceForm()
-    
+
     return render(request, "core/resource_create.html", {"form": form})
+
 
 @login_required
 @permission_required("core.change_resource", raise_exception=True)
@@ -65,14 +79,14 @@ def resource_update(request, pk):
     is_ajax = request.headers.get("X-Requested-With") == "XMLHttpRequest"
     resource = get_object_or_404(Resource, pk=pk)
     before = {
-        "name": resource.name, 
+        "name": resource.name,
         "resource_type": resource.resource_type,
         "environment": resource.environment,
         "url": resource.url,
         "is_active": resource.is_active,
     }
     if request.method == "POST":
-        form = ResourceForm(request.POST,instance=resource)
+        form = ResourceForm(request.POST, instance=resource)
         if form.is_valid():
             resource = form.save(commit=False)
             resource.save()
@@ -82,36 +96,42 @@ def resource_update(request, pk):
                 obj=resource,
                 before=before,
                 after={
-                    "name": resource.name, 
+                    "name": resource.name,
                     "resource_type": resource.resource_type,
                     "environment": resource.environment,
                     "url": resource.url,
                     "is_active": resource.is_active,
-                }
+                },
             )
-            return JsonResponse({"success": True}) if is_ajax else redirect("resource_list")
+            return (
+                JsonResponse({"success": True})
+                if is_ajax
+                else redirect("resource_list")
+            )
         elif is_ajax:
             return JsonResponse({"success": False, "errors": form.errors})
     elif is_ajax:
         return HttpResponseNotAllowed(["POST"])
     else:
         form = ResourceForm(instance=resource)
-    return render(request, "core/resource_update.html", {
-        "resource": resource,
-        "form": form
-    })
+    return render(
+        request, "core/resource_update.html", {"resource": resource, "form": form}
+    )
+
 
 @login_required
 @permission_required("core.change_resource", raise_exception=True)
 def resource_data(request, pk):
-    resource = get_object_or_404(Resource, pk = pk)
-    return JsonResponse({
-        "name": resource.name,
-        "resource_type": resource.resource_type,
-        "environment": resource.environment,
-        "url": resource.url,
-        "is_active": resource.is_active
-    })
+    resource = get_object_or_404(Resource, pk=pk)
+    return JsonResponse(
+        {
+            "name": resource.name,
+            "resource_type": resource.resource_type,
+            "environment": resource.environment,
+            "url": resource.url,
+            "is_active": resource.is_active,
+        }
+    )
 
 
 @login_required
@@ -120,7 +140,7 @@ def resource_delete(request, pk):
     resource = get_object_or_404(Resource, pk=pk)
     if request.method == "POST":
         before = {
-            "name": resource.name, 
+            "name": resource.name,
             "resource_type": resource.resource_type,
             "environment": resource.environment,
             "url": resource.url,
@@ -131,15 +151,14 @@ def resource_delete(request, pk):
             action=AuditLog.Action.RESOURCE_DELETED,
             obj=resource,
             before=before,
-            after=None
+            after=None,
         )
         resource.delete()
         is_ajax = request.headers.get("X-Requested-With") == "XMLHttpRequest"
         return JsonResponse({"success": True}) if is_ajax else redirect("resource_list")
     else:
-        return render(request, "core/resource_delete.html",{
-            "resource": resource
-        })
+        return render(request, "core/resource_delete.html", {"resource": resource})
+
 
 @login_required
 @permission_required("core.can_grant_access", raise_exception=True)
@@ -165,20 +184,29 @@ def grant_create(request, resource_pk):
                     "status": grant.status,
                     "start_at": grant.start_at.isoformat(),
                     "end_at": grant.end_at.isoformat(),
-                    "notes": grant.notes
-                }
+                    "notes": grant.notes,
+                },
             )
-            return JsonResponse({"success": True}) if is_ajax else redirect("resource_detail", pk=resource_pk)
+            return (
+                JsonResponse({"success": True})
+                if is_ajax
+                else redirect("resource_detail", pk=resource_pk)
+            )
         elif is_ajax:
             return JsonResponse({"success": False, "errors": form.errors})
     elif is_ajax:
         return HttpResponseNotAllowed(["POST"])
     else:
         form = AccessGrantForm()
-    return render(request, "core/grant_create.html", {
-        "resource": resource,
-        "form": form,
-    })
+    return render(
+        request,
+        "core/grant_create.html",
+        {
+            "resource": resource,
+            "form": form,
+        },
+    )
+
 
 @login_required
 @permission_required("core.can_revoke_access", raise_exception=True)
@@ -220,25 +248,29 @@ def grant_revoke(request, pk):
 @login_required
 @permission_required("core.can_grant_access", raise_exception=True)
 def user_list(request):
-    user = User.objects.values("id","username").order_by("username")
-    return JsonResponse({
-        "users": list(user)
-    })
+    user = User.objects.values("id", "username").order_by("username")
+    return JsonResponse({"users": list(user)})
 
 
 class CustomPasswordChangeView(PasswordChangeView):
     success_url = reverse_lazy("resource_list")
+
     def form_valid(self, form):
         self.request.user.profile.must_change_password = False
         self.request.user.profile.save()
         return super().form_valid(form)
 
+
 @login_required
 def user_profile(request):
     user = request.user
-    return render(request, "core/user_profile.html", {
-        "user": user,
-    })
+    return render(
+        request,
+        "core/user_profile.html",
+        {
+            "user": user,
+        },
+    )
 
 
 @login_required
@@ -246,10 +278,15 @@ def user_profile(request):
 def user_management(request):
     users = User.objects.all().prefetch_related("groups")
     groups = Group.objects.all()
-    return render(request, "core/user_management.html", {
-        "users": users,
-        "groups": groups,
-    })
+    return render(
+        request,
+        "core/user_management.html",
+        {
+            "users": users,
+            "groups": groups,
+        },
+    )
+
 
 @login_required
 @admin_required
@@ -259,7 +296,11 @@ def user_toggle_active(request, pk):
         was_active = user.is_active
         user.is_active = not user.is_active
         user.save()
-        action = AuditLog.Action.USER_ACTIVATED if not was_active else AuditLog.Action.USER_DEACTIVATED
+        action = (
+            AuditLog.Action.USER_ACTIVATED
+            if not was_active
+            else AuditLog.Action.USER_DEACTIVATED
+        )
         log_action(
             user=request.user,
             obj=user,
@@ -271,15 +312,22 @@ def user_toggle_active(request, pk):
     else:
         return JsonResponse({"success": False}, status=405)
 
+
 @login_required
 @admin_required
 def user_create(request):
     is_ajax = request.headers.get("X-Requested-With") == "XMLHttpRequest"
     if request.method == "POST":
-        form = UserForm(request.POST)
+        form = UserCreateForm(request.POST)
         if form.is_valid():
-            user = User.objects.create_user(username=form.cleaned_data['username'], password=form.cleaned_data['password'], email=form.cleaned_data['email'],first_name=form.cleaned_data['first_name'],last_name=form.cleaned_data['last_name'])
-            user.groups.add(form.cleaned_data['role'])
+            user = User.objects.create_user(
+                username=form.cleaned_data["username"],
+                password=form.cleaned_data["password"],
+                email=form.cleaned_data["email"],
+                first_name=form.cleaned_data["first_name"],
+                last_name=form.cleaned_data["last_name"],
+            )
+            user.groups.add(form.cleaned_data["role"])
             log_action(
                 user=request.user,
                 obj=user,
@@ -290,8 +338,8 @@ def user_create(request):
                     "email": user.email,
                     "first_name": user.first_name,
                     "last_name": user.last_name,
-                    "role": user.groups.first().name
-                }
+                    "role": user.groups.first().name,
+                },
             )
             return JsonResponse({"success": True})
         elif is_ajax:
@@ -301,18 +349,22 @@ def user_create(request):
     else:
         return redirect("user_management")
 
+
 @login_required
 @admin_required
 def user_data(request, pk):
     user = get_object_or_404(User, pk=pk)
     group = user.groups.first()
-    return JsonResponse({
-        "username": user.username,
-        "email": user.email,
-        "first_name": user.first_name,
-        "last_name": user.last_name,
-        "group": group.id if group is not None else None,
-    })
+    return JsonResponse(
+        {
+            "username": user.username,
+            "email": user.email,
+            "first_name": user.first_name,
+            "last_name": user.last_name,
+            "group": group.id if group is not None else None,
+        }
+    )
+
 
 @login_required
 @admin_required
@@ -331,8 +383,8 @@ def user_update(request, pk):
         if form.is_valid():
             user = form.save(commit=False)
             user.groups.clear()
-            user.groups.add(form.cleaned_data['role'])
-            password = form.cleaned_data.get('password')
+            user.groups.add(form.cleaned_data["role"])
+            password = form.cleaned_data.get("password")
             if password:
                 user.set_password(password)
             user.save()
@@ -347,7 +399,7 @@ def user_update(request, pk):
                     "first_name": user.first_name,
                     "last_name": user.last_name,
                     "role": user.groups.first().name if user.groups.exists() else None,
-                }
+                },
             )
             return JsonResponse({"success": True})
         elif is_ajax:
@@ -357,10 +409,15 @@ def user_update(request, pk):
     else:
         return redirect("user_management")
 
+
 @login_required
 @admin_required
 def audit_log(request):
     audit = AuditLog.objects.all().order_by("-timestamp").select_related("user")
-    return render(request, "core/audit_log.html", {
-        "audit": audit,
-    })
+    return render(
+        request,
+        "core/audit_log.html",
+        {
+            "audit": audit,
+        },
+    )

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -5,26 +5,28 @@ from core.models import Resource, AccessGrant
 from django.utils import timezone
 from datetime import timedelta
 
+
 @pytest.mark.django_db
 class TestResourceListView:
     def test_redirects_if_not_logged_in(self, client):
         response = client.get("/resources/")
         assert response.status_code == 302
-    
+
     def test_viewer_can_see_list(self, viewer_client):
         response = viewer_client.get("/resources/")
         assert response.status_code == 200
 
+
 @pytest.mark.django_db
 class TestResourceCreateView:
     def test_viewer_cannot_create(self, viewer_client):
-        response = viewer_client.post("/resources/create/", data={
-            "name": "test",
-            "resource_type": "server",
-            "environment": "dev"
-        }, HTTP_X_REQUESTED_WITH="XMLHttpRequest")
+        response = viewer_client.post(
+            "/resources/create/",
+            data={"name": "test", "resource_type": "server", "environment": "dev"},
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
         assert response.status_code == 403
-    
+
     def test_editor_can_create(self, editor_client):
         response = editor_client.post(
             "/resources/create/",
@@ -33,9 +35,10 @@ class TestResourceCreateView:
                 "resource_type": "server",
                 "environment": "dev",
             },
-            HTTP_X_REQUESTED_WITH="XMLHttpRequest"
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
         )
         assert response.status_code == 200
+
 
 @pytest.mark.django_db
 class TestResourceDeleteView:
@@ -45,21 +48,20 @@ class TestResourceDeleteView:
             resource_type="server",
         )
         response = editor_client.post(
-            f"/resources/{resource.pk}/delete/",
-            HTTP_X_REQUESTED_WITH="XMLHttpRequest"
+            f"/resources/{resource.pk}/delete/", HTTP_X_REQUESTED_WITH="XMLHttpRequest"
         )
         assert response.status_code == 403
-    
+
     def test_admin_can_delete(self, admin_client):
         resource = Resource.objects.create(
             name="test-user",
             resource_type="server",
         )
         response = admin_client.post(
-            f"/resources/{resource.pk}/delete/",
-            HTTP_X_REQUESTED_WITH="XMLHttpRequest"
+            f"/resources/{resource.pk}/delete/", HTTP_X_REQUESTED_WITH="XMLHttpRequest"
         )
         assert response.status_code == 200
+
 
 @pytest.mark.django_db
 class TestGrantCreateView:
@@ -73,14 +75,14 @@ class TestGrantCreateView:
             HTTP_X_REQUESTED_WITH="XMLHttpRequest",
         )
         assert response.status_code == 403
-    
+
     def test_admin_can_create_grant(self, admin_client):
         resource = Resource.objects.create(
             name="test-user",
             resource_type="server",
         )
         target_user = User.objects.create_user(username="target", password="pass")
-        
+
         response = admin_client.post(
             f"/resources/{resource.pk}/grants/create/",
             data={
@@ -92,6 +94,7 @@ class TestGrantCreateView:
             HTTP_X_REQUESTED_WITH="XMLHttpRequest",
         )
         assert response.status_code == 200
+
 
 @pytest.mark.django_db
 class TestGrantRevokeView:
@@ -110,7 +113,7 @@ class TestGrantRevokeView:
         )
         response = editor_client.post(f"/grants/{grant.pk}/revoke")
         assert response.status_code == 403
-    
+
     def test_admin_can_revoke(self, admin_client):
         target_user = User.objects.create_user(username="target", password="pass")
         resource = Resource.objects.create(
@@ -126,6 +129,7 @@ class TestGrantRevokeView:
         )
         response = admin_client.post(f"/grants/{grant.pk}/revoke")
         assert response.status_code == 302
+
 
 @pytest.mark.django_db
 class TestAuditLogView:
@@ -144,6 +148,7 @@ class TestAuditLogView:
     def test_admin_can_access(self, admin_client):
         response = admin_client.get("/audit_log/")
         assert response.status_code == 200
+
 
 @pytest.mark.django_db
 class TestUserCreateView:
@@ -165,17 +170,40 @@ class TestUserCreateView:
 
     def test_ajax_post_creates_user(self, admin_client):
         group = Group.objects.create(name="test-group")
-        response = admin_client.post("/users/create/", data={
-            "username": "newuser",
-            "email": "new@test.com",
-            "first_name": "New",
-            "last_name": "User",
-            "password": "testpass123",
-            "role": group.pk,
-        }, HTTP_X_REQUESTED_WITH="XMLHttpRequest")
+        response = admin_client.post(
+            "/users/create/",
+            data={
+                "username": "newuser",
+                "email": "new@test.com",
+                "first_name": "New",
+                "last_name": "User",
+                "password": "testpass123",
+                "role": group.pk,
+            },
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
         assert response.status_code == 200
         data = response.json()
         assert data["success"] is True
+
+    def test_ajax_post_requires_password(self, admin_client):
+        group = Group.objects.create(name="test-group")
+        response = admin_client.post(
+            "/users/create/",
+            data={
+                "username": "newuser",
+                "email": "new@test.com",
+                "first_name": "New",
+                "last_name": "User",
+                "role": group.pk,
+            },
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is False
+        assert "password" in data["errors"]
+
 
 @pytest.mark.django_db
 class TestUserUpdateView:


### PR DESCRIPTION
Closes #22

## Summary
- Require a password only when admins create new users.
- Keep password optional when admins edit existing users.
- Add targeted coverage for missing-password user creation.
- Add `.env.test` support and document Docker-based pytest usage.

## Changes
| File | Change |
|------|--------|
| `core/forms.py` | Adds `UserCreateForm` with required password |
| `core/views.py` | Uses `UserCreateForm` for user creation while keeping `UserForm` for updates |
| `tests/test_views.py` | Adds missing-password create-user test |
| `accessledger/settings_test.py` | Loads `.env.test` before building test DB settings |
| `.env.example` | Documents `.env.test` variables |
| `README.md`, `README.es.md` | Documents Docker-first test commands and local pytest override |

## Test Plan
- [x] `python3 -m py_compile core/forms.py core/views.py tests/test_views.py accessledger/settings_test.py`
- [x] `git diff --check`
- [x] `docker compose run --rm web pytest tests/test_views.py -k "UserCreate"`
- [x] Fresh-context review approved before commit/PR

## PR Type
- [x] Bug fix

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] Docs updated for test workflow
