### PR TITLE
fix(templates): prevent raw {% else %} tag from rendering in last-login column

### DIFF
--- a/core/templates/core/_user_management.html
+++ b/core/templates/core/_user_management.html
@@ -58,8 +58,8 @@
             {% endfor %}
           </td>
           <td class="muted last-login-cell">
-            {% if u.last_login %}{{ u.last_login|date:"d M Y, H:i" }}{% else
-            %}—{% endif %}
+            {% if u.last_login %}{{ u.last_login|date:"d M Y, H:i" }}{% else %}—
+            {% endif %}
           </td>
           <td>
             {% if u.is_active %}


### PR DESCRIPTION
Closes #38

## Summary
- Fixed split {% else %} tag in _user_management.html that was rendering as literal text
- Django template tags must be on a single line to parse correctly

## Changes
| File | Change |
|------|--------|
| core/templates/core/_user_management.html | Joined split {% else %} into single line |

## Before
```django
{% if u.last_login %}{{ u.last_login|date:"d M Y, H:i" }}{% else
%}—{% endif %}
```

## After
```django
{% if u.last_login %}{{ u.last_login|date:"d M Y, H:i" }}{% else %}—
{% endif %}
```