### PR TITLE
fix(grants): require POST for revoke

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -3,6 +3,7 @@ from django.contrib.auth.decorators import permission_required, login_required
 from django.core.exceptions import PermissionDenied
 from django.core.paginator import Paginator
 from django.http import JsonResponse, HttpResponseNotAllowed
+from django.views.decorators.http import require_POST
 from core.decorators import admin_required
 from core.forms import AccessGrantForm, ResourceForm, UserForm, UserCreateForm
 from core.permissions import user_can_modify_resource
@@ -243,39 +244,37 @@ def grant_create(request, resource_pk):
 
 @login_required
 @permission_required("core.can_revoke_access", raise_exception=True)
+@require_POST
 def grant_revoke(request, pk):
     grant = get_object_or_404(AccessGrant, pk=pk)
-    if request.method == "POST":
-        before = {
-            "user": grant.user.username,
-            "resource": grant.resource.name,
-            "access_level": grant.access_level,
-            "status": grant.status,
-            "start_at": grant.start_at.isoformat(),
-            "end_at": grant.end_at.isoformat() if grant.end_at else None,
-            "notes": grant.notes,
-        }
-        grant.status = AccessGrant.Status.REVOKED
-        grant.save()
-        after = {
-            "user": grant.user.username,
-            "resource": grant.resource.name,
-            "access_level": grant.access_level,
-            "status": grant.status,
-            "start_at": grant.start_at.isoformat(),
-            "end_at": grant.end_at.isoformat() if grant.end_at else None,
-            "notes": grant.notes,
-        }
-        log_action(
-            user=request.user,
-            action=AuditLog.Action.GRANT_REVOKED,
-            obj=grant,
-            before=before,
-            after=after,
-        )
-        return redirect("resource_detail", pk=grant.resource.pk)
-    else:
-        return redirect("resource_detail", pk=grant.resource.pk)
+    before = {
+        "user": grant.user.username,
+        "resource": grant.resource.name,
+        "access_level": grant.access_level,
+        "status": grant.status,
+        "start_at": grant.start_at.isoformat(),
+        "end_at": grant.end_at.isoformat() if grant.end_at else None,
+        "notes": grant.notes,
+    }
+    grant.status = AccessGrant.Status.REVOKED
+    grant.save()
+    after = {
+        "user": grant.user.username,
+        "resource": grant.resource.name,
+        "access_level": grant.access_level,
+        "status": grant.status,
+        "start_at": grant.start_at.isoformat(),
+        "end_at": grant.end_at.isoformat() if grant.end_at else None,
+        "notes": grant.notes,
+    }
+    log_action(
+        user=request.user,
+        action=AuditLog.Action.GRANT_REVOKED,
+        obj=grant,
+        before=before,
+        after=after,
+    )
+    return redirect("resource_detail", pk=grant.resource.pk)
 
 
 @login_required

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -391,37 +391,101 @@ class TestGrantCreateView:
 
 @pytest.mark.django_db
 class TestGrantRevokeView:
-    def test_editor_cannot_revoke(self, editor_client):
+    @staticmethod
+    def _make_active_grant():
+        """Create a fresh user, resource, and ACTIVE AccessGrant for revoke tests."""
         target_user = User.objects.create_user(username="target", password="pass")
         resource = Resource.objects.create(
-            name="test-server",
-            resource_type="server",
+            name="test-server", resource_type="server"
         )
-        grant = AccessGrant.objects.create(
+        return AccessGrant.objects.create(
             user=target_user,
             resource=resource,
             access_level=AccessGrant.AccessLevel.READ,
             start_at=timezone.now(),
             end_at=timezone.now() + timedelta(days=30),
         )
+
+    def test_editor_cannot_revoke(self, editor_client):
+        """Editor POST on /grants/<pk>/revoke must 403 AND leave grant ACTIVE with no audit row."""
+        grant = self._make_active_grant()
         response = editor_client.post(f"/grants/{grant.pk}/revoke")
+        # 403 — permission denied
         assert response.status_code == 403
+        # grant remains ACTIVE — permission check must run before any mutation
+        grant.refresh_from_db()
+        assert grant.status == AccessGrant.Status.ACTIVE
+        # no audit log row created on rejected POST
+        assert AuditLog.objects.filter(object_id=grant.pk).count() == 0
 
     def test_admin_can_revoke(self, admin_client):
-        target_user = User.objects.create_user(username="target", password="pass")
-        resource = Resource.objects.create(
-            name="test-server",
-            resource_type="server",
-        )
-        grant = AccessGrant.objects.create(
-            user=target_user,
-            resource=resource,
-            access_level=AccessGrant.AccessLevel.READ,
-            start_at=timezone.now(),
-            end_at=timezone.now() + timedelta(days=30),
-        )
+        grant = self._make_active_grant()
         response = admin_client.post(f"/grants/{grant.pk}/revoke")
         assert response.status_code == 302
+
+    def test_anonymous_get_redirects_to_login(self, client):
+        """Anonymous GET on /grants/<pk>/revoke must redirect to login, never mutate."""
+        grant = self._make_active_grant()
+        url = f"/grants/{grant.pk}/revoke"
+        response = client.get(url)
+        # 302 to login
+        assert response.status_code == 302
+        assert response.url.startswith("/login/")
+        assert f"next={url}" in response.url
+        # grant untouched, no audit row
+        grant.refresh_from_db()
+        assert grant.status == AccessGrant.Status.ACTIVE
+        assert AuditLog.objects.filter(object_id=grant.pk).count() == 0
+
+    def test_anonymous_post_redirects_to_login(self, client):
+        """Anonymous POST on /grants/<pk>/revoke must redirect to login, never mutate."""
+        grant = self._make_active_grant()
+        url = f"/grants/{grant.pk}/revoke"
+        response = client.post(url)
+        # 302 to login
+        assert response.status_code == 302
+        assert response.url.startswith("/login/")
+        assert f"next={url}" in response.url
+        # grant untouched, no audit row
+        grant.refresh_from_db()
+        assert grant.status == AccessGrant.Status.ACTIVE
+        assert AuditLog.objects.filter(object_id=grant.pk).count() == 0
+
+    def test_editor_get_returns_403(self, editor_client):
+        """Editor GET on /grants/<pk>/revoke must 403, never mutate."""
+        grant = self._make_active_grant()
+        response = editor_client.get(f"/grants/{grant.pk}/revoke")
+        assert response.status_code == 403
+        grant.refresh_from_db()
+        assert grant.status == AccessGrant.Status.ACTIVE
+        assert AuditLog.objects.filter(object_id=grant.pk).count() == 0
+
+    def test_admin_get_returns_405_and_does_not_mutate(self, admin_client):
+        """Admin GET on /grants/<pk>/revoke must return 405, leaving grant ACTIVE and no audit row."""
+        grant = self._make_active_grant()
+        response = admin_client.get(f"/grants/{grant.pk}/revoke")
+        # 405 is the new contract — previously this returned 302 (silent redirect).
+        assert response.status_code == 405
+        # grant stays ACTIVE
+        grant.refresh_from_db()
+        assert grant.status == AccessGrant.Status.ACTIVE
+        # no audit log row created on GET
+        assert AuditLog.objects.filter(object_id=grant.pk).count() == 0
+
+    def test_admin_post_revokes_and_writes_audit_log(self, admin_client):
+        """Admin POST on /grants/<pk>/revoke must revoke the grant and write GRANT_REVOKED audit row."""
+        grant = self._make_active_grant()
+        response = admin_client.post(f"/grants/{grant.pk}/revoke")
+        # redirects to resource detail for this grant
+        assert response.status_code == 302
+        assert response.url == f"/resources/{grant.resource.pk}/"
+        grant.refresh_from_db()
+        assert grant.status == AccessGrant.Status.REVOKED
+        # exactly one GRANT_REVOKED audit row for this grant
+        audit_rows = AuditLog.objects.filter(
+            object_id=grant.pk, action=AuditLog.Action.GRANT_REVOKED
+        )
+        assert audit_rows.count() == 1
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Reject authorized GET requests with 405 while preserving login redirects, permission denials, POST revocation, and audit logging.