### PR TITLE
feat(adapters): add V2 adapter skeleton

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -2,7 +2,7 @@
 
 # 🔐 AccessLedger
 
-**Sistema interno de control de accesos desarrollado con Django — gestiona, audita y aplica permisos sobre los recursos de una organización.**
+**Sistema interno de control de accesos desarrollado con Django — gestiona, audita y gobierna los permisos sobre los recursos de una organización.**
 
 ![Python](https://img.shields.io/badge/Python-3.12-3776AB?logo=python&logoColor=white)
 ![Django](https://img.shields.io/badge/Django-5.2-092E20?logo=django&logoColor=white)
@@ -304,7 +304,7 @@ La seguridad es una prioridad de primer nivel en AccessLedger. Se han implementa
 
 - **Protección contra fuerza bruta** — `django-axes` monitoriza los intentos de inicio de sesión; tras **5 intentos fallidos**, la cuenta se bloquea durante **1 hora**
 - **Cambio de contraseña forzado** — el middleware personalizado `ForcePasswordChangeMiddleware` redirige a los nuevos usuarios para que cambien su contraseña inicial antes de acceder a cualquier recurso
-- **Acceso basado en roles** — el decorador `@permission_required` de Django aplica permisos por grupo; un decorador personalizado `@admin_required` protege las vistas exclusivas de administración
+- **Acceso basado en roles** — el decorador `@permission_required` de Django controla los permisos por grupo; un decorador personalizado `@admin_required` protege las vistas exclusivas de administración
 - **Seguridad de sesión** — framework de sesiones integrado de Django con configuración segura por defecto
 
 ### Integridad de datos
@@ -399,6 +399,13 @@ POSTGRES_HOST=127.0.0.1 POSTGRES_PORT=5434 pytest -v
 ---
 
 ## 🗺 Hoja de ruta
+
+> **Fundamentos V2 (esqueleto).** Existe un contrato de adaptadores V2
+> bajo `core/adapters/` para describir — y eventualmente integrar con —
+> servicios externos. El esqueleto es **no-op**: no hay integración
+> real con proveedores, no hay ejecución programada, y no hay I/O de
+> producción. Los adaptadores reales son ciclos SDD futuros; consulta
+> `docs/adapters.md` para ver el contrato y los no-objetivos explícitos.
 
 - [ ] Registro de cambios de contraseña en el audit log
 - [ ] API REST con Django REST Framework

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # 🔐 AccessLedger
 
-**Internal access control system built with Django — manage, audit, and enforce resource permissions across your organization.**
+**Internal access control system built with Django — track, audit, and govern resource permissions across your organization.**
 
 ![Python](https://img.shields.io/badge/Python-3.12-3776AB?logo=python&logoColor=white)
 ![Django](https://img.shields.io/badge/Django-5.2-092E20?logo=django&logoColor=white)
@@ -304,7 +304,7 @@ Security is a first-class concern in AccessLedger. The following measures are im
 
 - **Brute force protection** — `django-axes` monitors login attempts; after **5 failed attempts**, the account is locked for **1 hour**
 - **Forced password change** — custom `ForcePasswordChangeMiddleware` redirects new users to change their initial password before accessing any resource
-- **Role-based access** — Django's `@permission_required` decorator enforces per-group permissions; a custom `@admin_required` decorator protects admin-only views
+- **Role-based access** — Django's `@permission_required` decorator controls per-group permissions; a custom `@admin_required` decorator protects admin-only views
 - **Session security** — Django's built-in session framework with secure defaults
 
 ### Data Integrity
@@ -399,6 +399,13 @@ POSTGRES_HOST=127.0.0.1 POSTGRES_PORT=5434 pytest -v
 ---
 
 ## 🗺 Roadmap
+
+> **V2 foundations (skeleton).** A V2 adapter contract exists under
+> `core/adapters/` for describing — and one day integrating with —
+> external services. The skeleton is **no-op**: no live provider
+> integration, no scheduled execution, and no production I/O. Real
+> adapters are future SDD cycles; see `docs/adapters.md` for the
+> contract and the explicit non-goals.
 
 - [ ] Password change events in the audit log
 - [ ] REST API with Django REST Framework

--- a/core/adapters/__init__.py
+++ b/core/adapters/__init__.py
@@ -1,0 +1,8 @@
+"""V2 adapter contract public surface."""
+from .base import ResourceAdapter, SyncResult
+from .demo import DemoAdapter
+from .registry import (AdapterLookupError, AdapterRegistrationError,
+                       get_adapter, register)
+
+__all__ = ["ResourceAdapter", "SyncResult", "register", "get_adapter",
+           "AdapterRegistrationError", "AdapterLookupError", "DemoAdapter"]

--- a/core/adapters/base.py
+++ b/core/adapters/base.py
@@ -1,0 +1,21 @@
+"""Adapter base contract: ABC + frozen SyncResult."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SyncResult:
+    """Outcome of an adapter sync(). ok + optional human-readable detail."""
+    ok: bool
+    detail: str = ""
+
+
+class ResourceAdapter(ABC):
+    """Abstract base for V2 external service adapters."""
+
+    @abstractmethod
+    def sync(self) -> SyncResult:
+        """Run the adapter's synchronization and return its outcome."""
+        ...

--- a/core/adapters/demo.py
+++ b/core/adapters/demo.py
@@ -1,0 +1,18 @@
+"""Demo adapter: explicit NO-OP, manual demonstration only.
+
+``DemoAdapter`` returns success without any external I/O, DB writes, or
+provider-specific work. The ``DEMO / no-op`` detail string makes the
+non-production intent unambiguous.
+"""
+from __future__ import annotations
+
+from .base import ResourceAdapter, SyncResult
+from .registry import register
+
+
+@register
+class DemoAdapter(ResourceAdapter):
+    """Explicit no-op adapter. Returns a successful DEMO / no-op result."""
+
+    def sync(self) -> SyncResult:
+        return SyncResult(ok=True, detail="DEMO / no-op")

--- a/core/adapters/registry.py
+++ b/core/adapters/registry.py
@@ -1,0 +1,54 @@
+"""Adapter registry: in-memory whitelist of admissible adapter targets.
+
+Only @register-decorated ResourceAdapter subclasses are resolvable.
+Unregistered targets are rejected even when importable.
+"""
+from __future__ import annotations
+
+from .base import ResourceAdapter
+
+
+class AdapterRegistrationError(ValueError):
+    """Raised when a class cannot be registered as an adapter."""
+
+
+class AdapterLookupError(KeyError):
+    """Raised when the registry cannot resolve a requested adapter path."""
+
+    def __init__(self, dotted_path: str) -> None:
+        super().__init__(dotted_path)
+        self.dotted_path = dotted_path
+
+    def __str__(self) -> str:
+        return f"Adapter '{self.dotted_path}' is not registered. Only classes explicitly @register-decorated can be resolved."
+
+
+# dotted path -> adapter class
+_registry: dict[str, type[ResourceAdapter]] = {}
+
+
+def register(cls: type[ResourceAdapter]) -> type[ResourceAdapter]:
+    """Class decorator: validate and store ``cls`` by its dotted path."""
+    if not isinstance(cls, type):
+        raise AdapterRegistrationError(f"@register target must be a class, got {type(cls).__name__}")
+    if not issubclass(cls, ResourceAdapter):
+        raise AdapterRegistrationError(f"{cls!r} must subclass ResourceAdapter to be registered")
+    abstract = getattr(cls, "__abstractmethods__", frozenset())
+    if abstract:
+        raise AdapterRegistrationError(f"{cls!r} has unimplemented abstract methods: {sorted(abstract)}")
+    _registry[f"{cls.__module__}.{cls.__qualname__}"] = cls
+    return cls
+
+
+def get_adapter(dotted_path: str) -> ResourceAdapter:
+    """Resolve a registered adapter path to a fresh instance. Never imports."""
+    if not dotted_path:
+        raise AdapterLookupError("")
+    try:
+        cls = _registry[dotted_path]
+    except KeyError as exc:
+        raise AdapterLookupError(dotted_path) from exc
+    return cls()
+
+
+__all__ = ["AdapterRegistrationError", "AdapterLookupError", "register", "get_adapter"]

--- a/core/management/commands/demo_sync.py
+++ b/core/management/commands/demo_sync.py
@@ -1,0 +1,36 @@
+"""Manual demo command for the V2 adapter skeleton.
+
+Prints a ``DEMO / no-op`` banner. NO external I/O or DB writes.
+"""
+from __future__ import annotations
+
+from django.core.management.base import BaseCommand, CommandError
+
+from core.adapters import registry
+from core.adapters.demo import DemoAdapter  # noqa: F401 — triggers @register
+
+
+DEFAULT_ADAPTER_PATH = f"{DemoAdapter.__module__}.{DemoAdapter.__qualname__}"
+
+
+class Command(BaseCommand):
+    help = "Run a demo adapter sync (DEMO / no-op — no real I/O)."
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument("--adapter", default=DEFAULT_ADAPTER_PATH,
+                            help="Dotted path of a registered adapter to run.")
+
+    def handle(self, *args, **options) -> None:
+        adapter_path: str = options["adapter"]
+        try:
+            adapter = registry.get_adapter(adapter_path)
+        except registry.AdapterLookupError as exc:
+            raise CommandError(str(exc)) from exc
+
+        result = adapter.sync()
+        self.stdout.write(f"adapter: {adapter_path}")
+        self.stdout.write(f"ok: {result.ok}")
+        self.stdout.write(f"detail: {result.detail}")
+        self.stdout.write("DEMO / no-op — no external I/O was performed.")
+        if not result.ok:
+            raise CommandError(f"Adapter {adapter_path} reported failure: {result.detail}")

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -1,0 +1,75 @@
+# External Service Adapters — Contract (V2 Skeleton)
+
+The V2 adapter layer is a **skeleton only**: it defines the shape of a future integration with external services, without performing any real I/O or shipping a live integration.
+
+> **TL;DR.** `ResourceAdapter` is an ABC with one method (`sync()`). Adapters are whitelisted through a module-level registry. The `DemoAdapter` and the `demo_sync` management command are explicit **no-op** demonstration helpers. Nothing here talks to the network, the database, or a real provider.
+
+## Why this exists
+
+V2 work is a foundation: it makes it possible to describe — and one day integrate with — external services (repos, VPNs, SaaS dashboards) without breaking the current application surface. The skeleton establishes the **adapter contract**, the **registry**, an **explicit no-op demo**, and the **non-goals** so future readers cannot mistake the skeleton for a working integration.
+
+## The contract
+```python
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class SyncResult:
+    ok: bool
+    detail: str = ""
+
+class ResourceAdapter(ABC):
+    @abstractmethod
+    def sync(self) -> SyncResult:
+        ...
+```
+- `sync()` returns a `SyncResult` describing success or failure.
+- Adapters are synchronous, in-memory, and side-effect-free.
+- `SyncResult` is a **frozen** dataclass; it is not mutable.
+
+## The registry
+```python
+from core.adapters import register, get_adapter
+
+@register
+class MyAdapter(ResourceAdapter):
+    def sync(self) -> SyncResult:
+        return SyncResult(ok=True, detail="ok")
+
+adapter = get_adapter("core.adapters.demo.DemoAdapter")
+```
+Hard rules enforced by the registry:
+
+1. Only classes decorated with `@register` and that subclass `ResourceAdapter` are resolvable.
+2. `get_adapter` **never** calls `importlib`. Unregistered targets are rejected with `AdapterLookupError` even when the path is importable by other means.
+3. The storage key is the class's fully-qualified dotted path (`module.qualname`); no aliasing, no DB-stored path, no settings-driven config.
+
+> **Foot-gun warning.** `importlib.import_string` is intentionally NOT used at the resolution site. A future contributor who adds it "to be helpful" reintroduces a code-execution surface the registry was designed to remove.
+
+## The demo
+```python
+@register
+class DemoAdapter(ResourceAdapter):
+    def sync(self) -> SyncResult:
+        return SyncResult(ok=True, detail="DEMO / no-op")
+```
+- `DemoAdapter` returns success without any work.
+- The literal string `DEMO / no-op` is part of the contract: the demo must identify itself as a non-production placeholder.
+- There is no "real" demo, no stub provider, and no flag to flip the demo into a live adapter. A real adapter is a future SDD change.
+
+## The management command
+```
+python manage.py demo_sync                          # default: runs the demo
+python manage.py demo_sync --adapter core.adapters.demo.DemoAdapter
+```
+- Default invocation: prints a `DEMO / no-op` banner, exits 0.
+- Unknown `--adapter`: prints a `CommandError`, exits non-zero.
+- The command does not import arbitrary targets; the registry's whitelist is the only source of admissible adapter paths.
+
+## What this is NOT
+
+This skeleton is intentionally **not**: a live GitHub / VPN / SaaS integration; a scheduled job (no Celery beat, no cron, no signal-based retry loop); a database-backed configuration (no `AdapterConfig` model, no stored import path, no JSON settings column — the whitelist is in-memory); a real RBAC extension (no new permission, no new group, no admin change); or an audit-log target (the demo does not write `AuditLog` entries). If you find yourself adding any of the above, stop: that is **V2 Option B** scope, not Option A, and requires its own proposal.
+
+## Roadmap
+
+A real adapter is **future work** and not part of this PR. When it lands, it will inherit from `ResourceAdapter`, be `@register`-decorated, be selected explicitly via `--adapter <dotted.path>`, and be reviewed in its own SDD cycle with its own scope, tests, and acceptance criteria.

--- a/tests/test_adapters_base.py
+++ b/tests/test_adapters_base.py
@@ -1,0 +1,28 @@
+"""Tests for the adapter base contract."""
+import pytest
+from dataclasses import FrozenInstanceError, fields
+
+from core.adapters.base import ResourceAdapter, SyncResult
+
+
+class TestAdapterBaseContract:
+    def test_syncresult_has_ok_and_detail_fields(self):
+        assert {f.name for f in fields(SyncResult)} == {"ok", "detail"}
+
+    def test_syncresult_default_detail_is_empty_string(self):
+        assert SyncResult(ok=True).detail == ""
+
+    def test_syncresult_is_frozen_assignment_raises(self):
+        sr = SyncResult(ok=True, detail="x")
+        with pytest.raises(FrozenInstanceError):
+            sr.ok = False  # type: ignore[misc]
+
+    def test_cannot_instantiate_resourceadapter_directly(self):
+        with pytest.raises(TypeError):
+            ResourceAdapter()  # type: ignore[abstract]
+
+    def test_subclass_without_sync_is_still_abstract(self):
+        class _Incomplete(ResourceAdapter):
+            pass
+        with pytest.raises(TypeError):
+            _Incomplete()  # type: ignore[abstract]

--- a/tests/test_adapters_demo.py
+++ b/tests/test_adapters_demo.py
@@ -1,0 +1,33 @@
+"""Tests for the demo (no-op) adapter. Per spec: DemoAdapter.sync()
+returns ok with the DEMO / no-op detail; no DB or network I/O."""
+import inspect
+
+from core.adapters.base import SyncResult
+from core.adapters.demo import DemoAdapter
+
+
+class TestDemoAdapter:
+    def test_returns_ok_true_with_no_op_detail(self):
+        result = DemoAdapter().sync()
+        assert isinstance(result, SyncResult)
+        assert result.ok is True
+        assert "no-op" in result.detail
+        assert "DEMO" in result.detail
+
+    def test_is_idempotent(self):
+        a = DemoAdapter().sync()
+        b = DemoAdapter().sync()
+        assert a.ok == b.ok
+        assert a.detail == b.detail
+
+    def test_demo_module_does_not_import_models(self):
+        from core.adapters import demo as demo_module
+        for name in dir(demo_module):
+            mod = getattr(getattr(demo_module, name), "__module__", "")
+            assert not mod.startswith("core.models"), f"Demo module leaked ORM import: {name} from {mod}"
+
+    def test_sync_method_body_has_no_io_tokens(self):
+        source = inspect.getsource(DemoAdapter.sync)
+        forbidden = ("open(", "requests.", "httpx.", "aiohttp", "urllib", "socket", "Resource.", "AccessGrant.", ".save(")
+        for token in forbidden:
+            assert token not in source, f"DemoAdapter.sync body should not contain '{token}': {source}"

--- a/tests/test_adapters_registry.py
+++ b/tests/test_adapters_registry.py
@@ -1,0 +1,62 @@
+"""Tests for the adapter registry. Per spec: @register accepts
+ResourceAdapter subclasses and rejects non-adapters; get_adapter rejects
+unregistered paths WITHOUT importing anything."""
+import importlib
+
+import pytest
+
+from core.adapters.base import ResourceAdapter, SyncResult
+from core.adapters import registry
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    registry._registry.clear()
+    yield
+    registry._registry.clear()
+
+
+class _StubAdapter(ResourceAdapter):
+    def sync(self):
+        return SyncResult(ok=True, detail="stub")
+
+
+class TestRegisterDecoratorAcceptsValidAdapter:
+    def test_register_makes_adapter_resolvable(self):
+        registry.register(_StubAdapter)
+        path = f"{_StubAdapter.__module__}.{_StubAdapter.__qualname__}"
+        instance = registry.get_adapter(path)
+        assert isinstance(instance, _StubAdapter)
+
+
+class TestRegisterDecoratorRejectsNonAdapters:
+    def test_rejects_plain_class_without_resourceadapter_base(self):
+        class _NotAnAdapter:
+            def sync(self):
+                return SyncResult(ok=True)
+        with pytest.raises(registry.AdapterRegistrationError):
+            registry.register(_NotAnAdapter)
+
+    def test_rejects_function_target(self):
+        def _not_a_class():
+            return SyncResult(ok=True)
+        with pytest.raises(registry.AdapterRegistrationError):
+            registry.register(_not_a_class)
+
+
+class TestGetAdapterRejection:
+    def test_unknown_path_raises(self):
+        with pytest.raises(registry.AdapterLookupError):
+            registry.get_adapter("does.not.exist.X")
+
+    def test_empty_path_raises(self):
+        with pytest.raises(registry.AdapterLookupError):
+            registry.get_adapter("")
+
+    def test_importable_but_unregistered_class_is_rejected(self):
+        """The autouse fixture cleared the registry, so even an importable
+        class at the path must be rejected."""
+        path = f"{_StubAdapter.__module__}.{_StubAdapter.__qualname__}"
+        assert importlib.import_module(_StubAdapter.__module__).__dict__.get(_StubAdapter.__qualname__) is _StubAdapter
+        with pytest.raises(registry.AdapterLookupError):
+            registry.get_adapter(path)

--- a/tests/test_management_demo_sync.py
+++ b/tests/test_management_demo_sync.py
@@ -1,0 +1,40 @@
+"""Tests for the `demo_sync` management command."""
+import io
+import importlib
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+import core.adapters.demo  # noqa: F401  — triggers @register on import
+
+
+@pytest.fixture(autouse=True)
+def _ensure_demo_registered():
+    importlib.reload(core.adapters.demo)
+    yield
+
+
+class TestDemoSyncCommand:
+    def test_default_run_succeeds_and_prints_banner(self):
+        out = io.StringIO()
+        call_command("demo_sync", stdout=out)
+        output = out.getvalue()
+        assert "DEMO" in output
+        assert "no-op" in output
+
+    def test_explicit_demo_path_succeeds(self):
+        out = io.StringIO()
+        call_command("demo_sync", "--adapter", "core.adapters.demo.DemoAdapter", stdout=out)
+        assert "DEMO" in out.getvalue()
+
+    def test_unknown_dotted_path_raises_command_error(self):
+        with pytest.raises(CommandError):
+            call_command("demo_sync", "--adapter", "does.not.exist.X", stdout=io.StringIO())
+
+    def test_unregistered_but_importable_path_raises_command_error(self):
+        """A path that resolves via importlib but was never @registered
+        must be rejected — the registry must not silently import."""
+        fake_path = f"{__name__}._definitely_not_registered"
+        with pytest.raises(CommandError):
+            call_command("demo_sync", "--adapter", fake_path, stdout=io.StringIO())


### PR DESCRIPTION
## Summary
- Add a no-op V2 adapter skeleton with a base contract, registry, and demo adapter.
- Add a manual `demo_sync` management command that proves the contract without external I/O or DB writes.
- Document adapter boundaries and soften README wording so AccessLedger is framed as track/audit/govern today, with real integrations as future work.

## Safety fences
- No migrations, models, views, URLs, admin, settings, requirements, permissions, fixtures, audit-log changes, credentials, scheduling, or real external I/O.
- `.windsurf/` remains local-only and is not included.
- Changed-line budget: 393 insertions / 4 deletions.

## Tests
- [x] Docker full suite: `docker compose run --rm web pytest -v` → 229 passed, 0 failed, 1 warning.
- [x] Adapter tests: `docker compose run --rm web pytest -v tests/test_adapters_base.py tests/test_adapters_demo.py tests/test_adapters_registry.py tests/test_management_demo_sync.py` → 19 passed.
- [x] Fresh SDD verify: PASS WITH WARNINGS; no critical issues.

## Notes
- `demo_sync` is intentionally a NO-OP demo command, not a real integration.
- Future security hardening and cleanup branches are planned separately in Engram.