### PR TITLE
test(cleanup): endurecer limpieza pre-entrega

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -351,15 +351,7 @@ AccessLedger cuenta con una interfaz de usuario con **tema oscuro** personalizad
 
 ## 🧪 Tests
 
-El proyecto incluye una suite de 22 tests automatizados construida con pytest-django, cubriendo tres capas:
-
-| Capa | Archivo | Tests |
-|------|---------|-------|
-| Validación de formularios | `tests/test_forms.py` | 7 |
-| Lógica de modelos y señales | `tests/test_models.py` | 4 |
-| Permisos de vistas y flujos de usuario | `tests/test_views.py` | 11 |
-
-Los tests verifican casos borde en formularios (nombres duplicados, rangos de fechas inválidos), los métodos `__str__` de los modelos, la creación automática de `Profile` mediante señales de Django, y que cada rol (`viewer`, `editor`, `admin`) solo puede acceder a las vistas que sus permisos permiten.
+El proyecto incluye una suite de tests con pytest-django que cubre casos borde de formularios (nombres duplicados, rangos de fechas inválidos), los métodos `__str__` de los modelos, la creación automática de `Profile` mediante señales de Django, y que cada rol (`viewer`, `editor`, `admin`) solo puede acceder a las vistas que sus permisos permiten. La suite se ejecuta con un único comando — consultá la invocación canónica más abajo; el conteo por archivo no se congela deliberadamente en este README.
 
 ### Recomendado: ejecutar tests dentro de Docker
 

--- a/README.md
+++ b/README.md
@@ -351,15 +351,7 @@ AccessLedger features a custom **dark theme UI** built entirely with native web 
 
 ## 🧪 Testing
 
-The project includes a suite of 22 automated tests built with pytest-django, covering three layers:
-
-| Layer | File | Tests |
-|-------|------|-------|
-| Form validation | `tests/test_forms.py` | 7 |
-| Model logic & signals | `tests/test_models.py` | 4 |
-| View permissions and user flows | `tests/test_views.py` | 11 |
-
-Tests verify form edge cases (duplicate names, invalid date ranges), model `__str__` methods, the auto-creation of `Profile` via Django signals, and that each role (`viewer`, `editor`, `admin`) can only access the views their permissions allow.
+The project ships with a pytest-django test suite that covers form edge cases (duplicate names, invalid date ranges), model `__str__` methods, the auto-creation of `Profile` via Django signals, and that each role (`viewer`, `editor`, `admin`) can only access the views their permissions allow. The suite is run as a single command — see below for the canonical invocation; the per-file test count is intentionally not frozen in this README.
 
 ### Recommended: run tests inside Docker
 

--- a/core/forms.py
+++ b/core/forms.py
@@ -1,6 +1,3 @@
-from dataclasses import fields
-from typing import Optional
-
 from django import forms
 from .models import AccessGrant, Resource
 from django.contrib.auth.models import User, Group

--- a/core/tests.py
+++ b/core/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/tests/test_adapters_registry.py
+++ b/tests/test_adapters_registry.py
@@ -44,6 +44,23 @@ class TestRegisterDecoratorRejectsNonAdapters:
             registry.register(_not_a_class)
 
 
+class TestRegisterDecoratorRejectsAbstractAdapters:
+    """Abstract / incomplete ResourceAdapter subclasses must be rejected so
+    a future refactor cannot silently allow non-concrete adapters into the
+    registry. Concrete adapters (control set: DemoAdapter) must still pass.
+    """
+
+    def test_rejects_resourceadapter_abc_itself(self):
+        with pytest.raises(registry.AdapterRegistrationError):
+            registry.register(ResourceAdapter)
+
+    def test_rejects_subclass_that_does_not_override_sync(self):
+        class _Incomplete(ResourceAdapter):
+            pass
+        with pytest.raises(registry.AdapterRegistrationError):
+            registry.register(_Incomplete)
+
+
 class TestGetAdapterRejection:
     def test_unknown_path_raises(self):
         with pytest.raises(registry.AdapterLookupError):

--- a/tests/test_management_demo_sync.py
+++ b/tests/test_management_demo_sync.py
@@ -7,12 +7,34 @@ from django.core.management import call_command
 from django.core.management.base import CommandError
 
 import core.adapters.demo  # noqa: F401  — triggers @register on import
+from core.adapters.base import ResourceAdapter, SyncResult
+from core.adapters import registry
 
 
 @pytest.fixture(autouse=True)
 def _ensure_demo_registered():
     importlib.reload(core.adapters.demo)
     yield
+
+
+class _FailingAdapter(ResourceAdapter):
+    """Stub adapter whose sync() reports ok=False. Registered locally inside
+    the boundary test (NOT at module import time) so that other test files'
+    registry-clearing teardowns do not strip the path before our test runs.
+    The class-level ``sync_calls`` counter lets the test prove the
+    ``CommandError`` originated from the ``ok=False`` boundary, not from
+    registry lookup failure (G2)."""
+
+    sync_calls = 0
+
+    def sync(self) -> SyncResult:
+        _FailingAdapter.sync_calls += 1
+        return SyncResult(ok=False, detail="synthetic failure")
+
+
+_FailingAdapter.__module__ = "tests.test_management_demo_sync"
+_FailingAdapter.__qualname__ = "_FailingAdapter"
+FAILING_ADAPTER_PATH = f"{_FailingAdapter.__module__}.{_FailingAdapter.__qualname__}"
 
 
 class TestDemoSyncCommand:
@@ -38,3 +60,29 @@ class TestDemoSyncCommand:
         fake_path = f"{__name__}._definitely_not_registered"
         with pytest.raises(CommandError):
             call_command("demo_sync", "--adapter", fake_path, stdout=io.StringIO())
+
+    def test_adapter_failure_raises_command_error_at_boundary(self):
+        """When the resolved adapter returns SyncResult(ok=False, ...), the
+        command boundary must surface that as CommandError so operators
+        see a clear failure (G2 — boundary-only contract).
+
+        The adapter is registered locally inside this test (not at module
+        import time) so prior test files clearing ``registry._registry``
+        in their teardowns cannot leave the path unregistered. The
+        ``sync_calls`` counter then forces the failure to have originated
+        in the ``ok=False`` branch: if the ``CommandError`` had come from
+        registry lookup (line 28 of demo_sync.py), the counter would
+        still be 0 and this assertion would fail — which is exactly the
+        false-positive the verification report flagged."""
+        _FailingAdapter.sync_calls = 0
+        registry.register(_FailingAdapter)
+        try:
+            with pytest.raises(CommandError):
+                call_command("demo_sync", "--adapter", FAILING_ADAPTER_PATH, stdout=io.StringIO())
+            assert _FailingAdapter.sync_calls == 1, (
+                f"Expected exactly one sync() call before boundary raise; "
+                f"got {_FailingAdapter.sync_calls}. If 0, the CommandError "
+                f"came from registry lookup, not from the ok=False boundary."
+            )
+        finally:
+            registry._registry.pop(FAILING_ADAPTER_PATH, None)


### PR DESCRIPTION
## Resumen

- Añade cobertura negativa para el registry de adapters sin cambiar la lógica de producción.
- Añade una prueba robusta para `demo_sync` cuando el adapter devuelve `ok=False`, verificando que el fallo sale del boundary correcto.
- Limpia imports muertos, elimina `core/tests.py` al confirmarse que era zombie, y actualiza el wording de tests en los README sin conteos congelados.

## Cambios

| Archivo | Cambio |
|---|---|
| `tests/test_adapters_registry.py` | Agrega tests para rechazar adapters abstractos/incompletos. |
| `tests/test_management_demo_sync.py` | Agrega adapter stub local y prueba `CommandError` en el path `SyncResult(ok=False)`. |
| `core/forms.py` | Borra dos imports muertos. |
| `core/tests.py` | Elimina el skeleton vacío de Django. |
| `README.md` | Reemplaza conteo fijo de tests por wording flexible. |
| `README.es.md` | Reemplaza conteo fijo de tests por wording flexible. |

## Fuera de alcance confirmado

- No se tocó `.windsurf/`.
- No se tocó `tests/test_views.py`.
- No se migró XHR/HTMX.
- No se refactorizaron fixtures.
- No se cambió el contrato de adapters.
- No se modificó código de producción de `registry.py` ni `demo_sync.py`.

## Evidencia de tests

- [x] `docker compose run --rm web pytest -v` → 232 passed, 1 warning.
- [x] Tests enfocados adapters/command → 22 passed.
- [x] Coverage objetivo confirma `core/management/commands/demo_sync.py:36` ejecutada.
- [x] `python manage.py test core` → Ran 0 tests, confirmando que `core/tests.py` no aportaba tests.

## Notas de SDD

- Proposal: `sdd/pre-delivery-quality-cleanup/proposal`
- Spec: `sdd/pre-delivery-quality-cleanup/spec`
- Design: `sdd/pre-delivery-quality-cleanup/design`
- Verify: PASS WITH WARNINGS; warnings no bloqueantes sobre grouping ya resuelto como PR único por decisión del maintainer.

## Checklist

- [x] Commit convencional.
- [x] PR único confirmado por maintainer.
- [x] Sin atribución AI / Co-Authored-By.
- [x] `.windsurf/` queda fuera del commit.