### PR TITLE
fix(security): close XSS in password_change_form USERNAME injection (#55)

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.contrib.auth.forms import PasswordChangeForm
 from .models import AccessGrant, Resource
 from django.contrib.auth.models import User, Group
 
@@ -37,3 +38,23 @@ class UserForm(forms.ModelForm):
 
 class UserCreateForm(UserForm):
     password = forms.CharField(required=True, widget=forms.PasswordInput)
+
+
+class CustomPasswordChangeForm(PasswordChangeForm):
+    """PasswordChangeForm variant that exposes the current username via the
+    ``data-username`` attribute on the new-password input.
+
+    This lets ``core/static/core/js/password_change.js`` read the username
+    without an inline ``<script>const USERNAME = "..."</script>`` block —
+    which was previously a reflected XSS vector for users with crafted
+    usernames (issue #55). Django's HTML autoescape escapes ``"`` to
+    ``&quot;`` inside the attribute, closing the escape hatch that the inline
+    JS string literal relied on.
+    """
+
+    def __init__(self, user, *args, **kwargs):
+        self.user = user
+        super().__init__(user, *args, **kwargs)
+        self.fields["new_password1"].widget.attrs["data-username"] = (
+            user.get_username()
+        )

--- a/core/forms.py
+++ b/core/forms.py
@@ -53,7 +53,8 @@ class CustomPasswordChangeForm(PasswordChangeForm):
     """
 
     def __init__(self, user, *args, **kwargs):
-        self.user = user
+        # NOTE: ``self.user`` is set by ``PasswordChangeForm.__init__`` via
+        # ``super().__init__(user, ...)``; no need to assign it again here.
         super().__init__(user, *args, **kwargs)
         if user is not None:
             self.fields["new_password1"].widget.attrs["data-username"] = (

--- a/core/forms.py
+++ b/core/forms.py
@@ -55,6 +55,7 @@ class CustomPasswordChangeForm(PasswordChangeForm):
     def __init__(self, user, *args, **kwargs):
         self.user = user
         super().__init__(user, *args, **kwargs)
-        self.fields["new_password1"].widget.attrs["data-username"] = (
-            user.get_username()
-        )
+        if user is not None:
+            self.fields["new_password1"].widget.attrs["data-username"] = (
+                user.get_username()
+            )

--- a/core/static/core/js/delegated.js
+++ b/core/static/core/js/delegated.js
@@ -217,6 +217,21 @@
 
   main.addEventListener('submit', function (e) {
     var form = e.target;
+
+    // XSS-safe confirm: any <form data-confirm="..."> triggers window.confirm
+    // with the (already HTML-escaped, browser-decoded) message from the
+    // data-confirm attribute. confirm() only displays text — it never
+    // evaluates it — so this is safe even when the message embeds a
+    // user-controlled string like a username (closes the same reflected-XSS
+    // class as the password_change_form fix for issue #55).
+    if (form.dataset && typeof form.dataset.confirm === 'string') {
+      if (!window.confirm(form.dataset.confirm)) {
+        e.preventDefault();
+        e.stopPropagation();
+        return;
+      }
+    }
+
     switch (form.id) {
       case 'formNewResource':   e.preventDefault(); onSubmitNewResource(e, form); break;
       case 'formEditResource':  e.preventDefault(); onSubmitEditResource(e, form); break;

--- a/core/static/core/js/password_change.js
+++ b/core/static/core/js/password_change.js
@@ -6,6 +6,7 @@ const COMMON = [
 ];
 
 const input = document.getElementById("id_new_password1");
+const USERNAME = input.dataset.username || "";
 const bars = [
   document.getElementById("bar1"),
   document.getElementById("bar2"),

--- a/core/static/core/js/password_change.js
+++ b/core/static/core/js/password_change.js
@@ -6,7 +6,7 @@ const COMMON = [
 ];
 
 const input = document.getElementById("id_new_password1");
-const USERNAME = input.dataset.username || "";
+const username = input.dataset.username || "";
 const bars = [
   document.getElementById("bar1"),
   document.getElementById("bar2"),
@@ -34,7 +34,7 @@ input.addEventListener("input", () => {
   const okLength  = val.length >= 8;
   const okNumeric = !/^\d+$/.test(val);
   const okCommon  = !COMMON.includes(val.toLowerCase());
-  const okSimilar = val.length === 0 || !val.toLowerCase().includes(USERNAME.toLowerCase());
+  const okSimilar = username.length === 0 || val.length === 0 || !val.toLowerCase().includes(username.toLowerCase());
 
   setHint(hints.length,  okLength);
   setHint(hints.numeric, okNumeric);

--- a/core/templates/core/resource_detail.html
+++ b/core/templates/core/resource_detail.html
@@ -132,7 +132,8 @@
             {% if perms.core.can_revoke_access %}
               <td>
                 {% if g.status == 'active' %}
-                  <form method="post" action="{% url 'grant_revoke' pk=g.pk %}" style="margin:0;" onsubmit="return confirm('¿Revocar acceso de @{{ g.user.username }}?')">
+                  {# XSS-safe confirm: the username is HTML-escaped by Django inside the data-confirm attribute and consumed by a delegated JS handler that calls confirm() — which only displays text and never evaluates it. Closes the same reflected-XSS class as password_change_form (issue #55). #}
+                  <form method="post" action="{% url 'grant_revoke' pk=g.pk %}" style="margin:0;" data-confirm="¿Revocar acceso de @{{ g.user.username }}?">
                     {% csrf_token %}
                     <button type="submit" style="padding:4px 12px; border:1px solid rgba(255,80,90,.3); border-radius:6px; background:rgba(255,80,90,.1); color:rgba(255,80,90,.85); font-size:12px; cursor:pointer;">
                       Revocar

--- a/core/views.py
+++ b/core/views.py
@@ -5,7 +5,7 @@ from django.core.paginator import Paginator
 from django.http import JsonResponse, HttpResponseNotAllowed
 from django.views.decorators.http import require_POST
 from core.decorators import admin_required
-from core.forms import AccessGrantForm, ResourceForm, UserForm, UserCreateForm
+from core.forms import AccessGrantForm, ResourceForm, UserForm, UserCreateForm, CustomPasswordChangeForm
 from core.permissions import user_can_modify_resource
 from .models import AccessGrant, Resource, Profile, AuditLog
 from django.contrib.auth.models import User, Group
@@ -285,6 +285,7 @@ def user_list(request):
 
 
 class CustomPasswordChangeView(PasswordChangeView):
+    form_class = CustomPasswordChangeForm
     success_url = reverse_lazy("resource_list")
 
     def get_context_data(self, **kwargs):

--- a/templates/registration/password_change_form.html
+++ b/templates/registration/password_change_form.html
@@ -101,6 +101,5 @@
 {% endblock %}
 
 {% block extra_js %}
-  <script>const USERNAME = "{{ request.user.username }}";</script>
   <script defer src="{% static 'core/js/password_change.js' %}"></script>
 {% endblock %}

--- a/tests/test_security_xss.py
+++ b/tests/test_security_xss.py
@@ -183,3 +183,45 @@ class TestPasswordChangeXSSRegression:
         assert response.status_code == 200
         actual = _data_username_value(response.content.decode())
         assert actual == xss_user.get_username()
+
+    def test_password_change_html_tag_username(self, client):
+        """HTML tags in the username remain escaped inside the attribute."""
+        username = "<b>test</b>"
+        user = User.objects.create_user(username=username, password="SafePass123!")
+        assert client.login(username=username, password="SafePass123!") is True
+
+        response = client.get("/password/change/")
+
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert "<b>test</b>" not in content
+        assert "&lt;b&gt;test&lt;/b&gt;" in content
+        assert _data_username_value(content) == user.get_username()
+
+    def test_password_change_backslash_username(self, client):
+        """Backslashes are preserved as data, not interpreted as JavaScript."""
+        username = r"evil\username"
+        user = User.objects.create_user(username=username, password="SafePass123!")
+        assert client.login(username=username, password="SafePass123!") is True
+
+        response = client.get("/password/change/")
+
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert 'const USERNAME = "' not in content
+        assert _data_username_value(content) == user.get_username()
+
+    def test_password_change_empty_username(self, client):
+        """An empty username is handled by the defensive form path."""
+        user = User(username="")
+        user.set_password("SafePass123!")
+        user.save()
+        assert client.login(username="", password="SafePass123!") is True
+
+        response = client.get("/password/change/")
+
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert 'id="id_new_password1"' in content
+        assert 'data-username=""' in content
+        assert _data_username_value(content) == user.get_username()

--- a/tests/test_security_xss.py
+++ b/tests/test_security_xss.py
@@ -172,8 +172,6 @@ class TestPasswordChangeXSSRegression:
         # ``&quot;`` (proof that the value is bound by the surrounding
         # attribute quotes and cannot step out into JS context).
         assert "&quot;" in content
-        # And no leftover JS-string-literal form of the username.
-        assert 'USERNAME = "x' not in content
 
     def test_password_change_username_value_matches_user(
         self, xss_client, xss_user

--- a/tests/test_security_xss.py
+++ b/tests/test_security_xss.py
@@ -1,51 +1,70 @@
-"""Regression tests for the reflected XSS in
-``templates/registration/password_change_form.html`` (issue #55).
+"""Regression tests for the reflected XSS class fixed in PR #71 (issue #55).
 
-The vulnerable template injected ``{{ request.user.username }}`` inside an
-inline ``<script>const USERNAME = "..."</script>`` block. Django's HTML
-autoescape only escapes HTML-significant characters (``"``, ``<``, ``>``,
-``&``); the browser HTML parser decodes ``&quot;`` back to ``"`` *before*
-the inline JavaScript parses, so a username such as
-``x"); alert(document.cookie);//`` could break out of the string literal and
-execute arbitrary code.
+Two templates in the codebase interpolated ``{{ user.username }}`` into
+inline JavaScript, which is the canonical reflected-XSS pattern: Django's
+HTML autoescape escapes HTML-significant characters (``"``, ``<``, ``>``,
+``&``, ``'``); the browser HTML parser decodes them back (``&quot;`` → ``"``,
+``&#x27;`` → ``'``) **before** the inline JavaScript parses, so a crafted
+username such as ``x"); alert(document.cookie);//`` could break out of
+the string literal and execute arbitrary code.
 
-The fix moves the username to a ``data-username="..."`` attribute on the
-new-password input (rendered via Django's widget-attr pipeline, so Django's
-autoescape escapes ``"`` to ``&quot;`` *inside the attribute value*, where
-the browser parser cannot use it to step out of the attribute). The
-inline ``<script>`` is removed; the password-strength JS reads the username
-from ``input.dataset.username``.
+Templates fixed by this PR:
+
+1. ``templates/registration/password_change_form.html`` — the inline
+   ``<script>const USERNAME = "{{ request.user.username }}";</script>``
+   block was removed; the username is now passed via a
+   ``data-username="..."`` attribute on the new-password input (Django
+   autoescape inside the attribute value closes the escape hatch).
+2. ``core/templates/core/resource_detail.html`` — the inline
+   ``onsubmit="return confirm('…@{{ g.user.username }}?')"`` handler was
+   replaced with a ``data-confirm="…"`` attribute consumed by a
+   delegated JS handler that calls ``window.confirm(...)``. ``confirm()``
+   only displays text — it never evaluates it — so the same escape
+   property holds even when the message embeds a user-controlled string.
 
 The contract enforced by these tests is therefore:
 
-1. The response body MUST NOT contain an inline ``<script>`` block that
-   embeds the username as a JavaScript string literal.
-2. The response body MUST NOT contain the ``USERNAME = "`` substring at
-   all (broader guard against future re-introductions).
-3. A user with a malicious username MUST render the page with HTTP 200
-   and the literal payload MUST NOT appear as a JS-executable fragment.
+1. The password-change response MUST NOT contain an inline ``<script>``
+   block that embeds the username as a JavaScript string literal.
+2. The password-change response MUST NOT contain the ``USERNAME = "``
+   substring at all (broader guard against future re-introductions).
+3. A user with a malicious username MUST render the password-change page
+   with HTTP 200 and the literal payload MUST NOT appear as a
+   JS-executable fragment.
 4. The new-password input MUST carry a ``data-username="..."`` attribute
    and the value MUST be HTML-escaped (so ``"`` becomes ``&quot;``).
 5. The decoded ``data-username`` attribute MUST equal
    ``user.get_username()`` for the authenticated user (round-trip
    contract that the JS consumer depends on).
+6. The resource-detail revoke form MUST NOT use an inline ``onsubmit``
+   handler that interpolates the username; it MUST use ``data-confirm``
+   carrying the HTML-escaped username.
 """
 
 from __future__ import annotations
 
 import html
 import re
+from datetime import timedelta
+from pathlib import Path
 
 import pytest
 from django.contrib.auth.models import User
 from django.test import Client
+from django.utils import timezone
+
+from core.models import AccessGrant, Resource
 
 
 # A canonical JS-injection payload. Django's default
-# ``UnicodeUsernameValidator`` allows ASCII letters, digits, and ``@.+-_``
-# plus any non-ASCII printable character. ``;``, ``"``, ``(``, ``)``,
-# ``/``, ``*``, ``!`` are all permitted; we exploit that here.
+# ``UnicodeUsernameValidator`` regex is ``^[\\w.@+-]+\\Z`` and rejects
+# these characters outright; ``User.objects.create_user`` skips that
+# validator (it does not call ``full_clean``), so the payload can still
+# be persisted via shell/scripted paths and remains a meaningful
+# regression target for the rendering layer. ``UnicodeUsernameValidator``
+# does NOT permit ``;``, ``"``, ``(``, ``)``, ``/``, ``*``, ``!``.
 XSS_PAYLOAD = 'x"); alert(document.cookie);//'
+XSS_PAYLOAD_SINGLE_QUOTE = "evil'); alert(1);//"
 
 
 @pytest.fixture
@@ -225,3 +244,271 @@ class TestPasswordChangeXSSRegression:
         assert 'id="id_new_password1"' in content
         assert 'data-username=""' in content
         assert _data_username_value(content) == user.get_username()
+
+    def test_password_change_skips_similarity_for_empty_username(self):
+        """An empty or missing username must not make every password similar."""
+        javascript = Path(
+            "core/static/core/js/password_change.js"
+        ).read_text()
+
+        assert re.search(
+            r"const okSimilar = username\.length === 0 \|\| .*includes\(username\.toLowerCase\(\)\)",
+            javascript,
+        )
+
+    def test_password_change_still_checks_nonempty_username(self):
+        """A populated username still participates in the similarity check."""
+        javascript = Path(
+            "core/static/core/js/password_change.js"
+        ).read_text()
+
+        assert re.search(
+            r"!val\.toLowerCase\(\)\.includes\(username\.toLowerCase\(\)\)",
+            javascript,
+        )
+
+
+def _data_confirm_value(content: str, action_url: str) -> str:
+    """Extract the value of the ``data-confirm`` attribute on the revoke
+    form (identified by its ``action`` URL), HTML-decoded.
+
+    Stdlib-only regex (no BeautifulSoup) to stay within the project's
+    test dependency set. Returns the HTML-decoded value so callers can
+    compare against ``user.get_username()`` directly.
+    """
+    # Find the <form> tag whose action attribute matches action_url.
+    # We anchor on `action="..."` to avoid matching other forms on the
+    # same page (e.g. hx-post forms in the resource detail header).
+    pattern = re.compile(
+        r'<form\b[^>]*\baction="' + re.escape(action_url) + r'"[^>]*>',
+        re.DOTALL,
+    )
+    match = pattern.search(content)
+    assert match is not None, (
+        f"expected a <form action=\"{action_url}\"> in the response; got: {content!r}"
+    )
+    tag = match.group(0)
+    attr_match = re.search(r'data-confirm="([^"]*)"', tag)
+    assert attr_match is not None, (
+        f"expected data-confirm attribute on the revoke form: {tag!r}"
+    )
+    return html.unescape(attr_match.group(1))
+
+
+@pytest.fixture
+def admin_viewer(db):
+    """An admin user who can view the resource detail page and revoke."""
+    return User.objects.create_user(
+        username="xss-admin",
+        password="SafePass123!",
+    )
+
+
+@pytest.fixture
+def malicious_target(db):
+    """A user whose username contains the single-quote XSS payload.
+
+    ``UnicodeUsernameValidator`` rejects ``'``; ``create_user`` skips
+    validators, so the user is persistable via shell/scripted paths.
+    """
+    User.objects.filter(username=XSS_PAYLOAD_SINGLE_QUOTE).delete()
+    return User.objects.create_user(
+        username=XSS_PAYLOAD_SINGLE_QUOTE,
+        password="SafePass123!",
+    )
+
+
+@pytest.fixture
+def active_grant_for(malicious_target):
+    """An ACTIVE AccessGrant for ``malicious_target`` on a fresh resource."""
+    resource = Resource.objects.create(
+        name="xss-target-server", resource_type="server"
+    )
+    return AccessGrant.objects.create(
+        user=malicious_target,
+        resource=resource,
+        access_level=AccessGrant.AccessLevel.READ,
+        start_at=timezone.now(),
+        end_at=timezone.now() + timedelta(days=30),
+    )
+
+
+@pytest.mark.django_db
+class TestResourceDetailRevokeXSSRegression:
+    """Regression contract for the same XSS class as issue #55, on the
+    revoke form in ``core/templates/core/resource_detail.html``.
+
+    The vulnerable template used an inline ``onsubmit="return
+    confirm('…@{{ g.user.username }}?')"`` handler. A username containing
+    ``'`` (e.g. ``evil'); alert(1);//``) breaks out of the ``confirm()``
+    string literal because Django autoescape escapes ``'`` to ``&#x27;``
+    and the browser decodes it back to ``'`` before the JS handler runs.
+
+    The fix replaces ``onsubmit`` with a ``data-confirm`` attribute; a
+    delegated JS handler (``core/static/core/js/delegated.js``) reads
+    ``form.dataset.confirm`` and calls ``window.confirm(...)``. Because
+    ``confirm()`` only displays text, the same autoescape property holds.
+    """
+
+    def test_revoke_form_has_no_inline_onsubmit(
+        self, admin_client, active_grant_for
+    ):
+        """REQ-SEC-6.1: revoke form must not use an inline onsubmit
+        handler that interpolates the username.
+        """
+        url = f"/resources/{active_grant_for.resource.pk}/"
+        response = admin_client.get(url)
+        assert response.status_code == 200
+        content = response.content.decode()
+        revoke_url = f"/grants/{active_grant_for.pk}/revoke"
+        # No inline JS handler on the revoke form. The whole class of
+        # reflected XSS via `onsubmit="...{{ username }}..."` must be
+        # absent — not just for this user, but structurally.
+        pattern = re.compile(
+            r'<form\b[^>]*\baction="' + re.escape(revoke_url) + r'"[^>]*>',
+            re.DOTALL,
+        )
+        match = pattern.search(content)
+        assert match is not None, (
+            f"expected a revoke <form action=\"{revoke_url}\">; got: {content!r}"
+        )
+        assert "onsubmit" not in match.group(0), (
+            "revoke form still has an inline onsubmit handler: "
+            f"{match.group(0)!r}"
+        )
+
+    def test_revoke_form_has_data_confirm_attribute(
+        self, admin_client, active_grant_for
+    ):
+        """REQ-SEC-6.2: the revoke form must carry a ``data-confirm="…"``
+        attribute holding the confirmation message.
+
+        The malicious username contains a single quote (``'``) which the
+        old ``onsubmit="return confirm('…')"`` handler allowed to break
+        out of the JS string literal. We verify the load-bearing safety
+        property: the raw HTML escapes ``'`` to ``&#x27;`` inside the
+        attribute, and the decoded value (what the JS handler passes to
+        ``confirm()``) embeds the original username.
+        """
+        url = f"/resources/{active_grant_for.resource.pk}/"
+        response = admin_client.get(url)
+        assert response.status_code == 200
+        content = response.content.decode()
+        revoke_url = f"/grants/{active_grant_for.pk}/revoke"
+
+        # 1) Raw HTML: the single-quote in the malicious username must
+        #    be HTML-escaped to ``&#x27;`` inside the data-confirm
+        #    attribute. This is what prevents the browser from decoding
+        #    it back to ``'`` and stepping out of the JS string literal.
+        revoke_form_match = re.search(
+            r'<form\b[^>]*\baction="' + re.escape(revoke_url) + r'"[^>]*>',
+            content,
+            re.DOTALL,
+        )
+        assert revoke_form_match is not None
+        assert "&#x27;" in revoke_form_match.group(0), (
+            "single-quote not HTML-escaped in raw form HTML: "
+            f"{revoke_form_match.group(0)!r}"
+        )
+
+        # 2) Decoded message: after the browser decodes &#x27; back to '
+        #    inside the attribute and the JS reads form.dataset.confirm,
+        #    the message must contain the original username (round-trip
+        #    contract that makes the confirm dialog useful).
+        value = _data_confirm_value(content, revoke_url)
+        assert "¿Revocar acceso de @" in value
+        assert XSS_PAYLOAD_SINGLE_QUOTE in value, (
+            f"decoded confirm message missing username: {value!r}"
+        )
+
+    def test_revoke_form_decoded_confirm_matches_username(
+        self, admin_client, active_grant_for, malicious_target
+    ):
+        """REQ-SEC-6.3: the decoded data-confirm value must embed the
+        user's username (round-trip contract that the delegated JS
+        handler depends on to display a useful message).
+        """
+        url = f"/resources/{active_grant_for.resource.pk}/"
+        response = admin_client.get(url)
+        content = response.content.decode()
+        revoke_url = f"/grants/{active_grant_for.pk}/revoke"
+        value = _data_confirm_value(content, revoke_url)
+        assert malicious_target.get_username() in value
+
+    def test_revoke_form_with_double_quote_username(
+        self, admin_client, active_grant_for
+    ):
+        """A double-quote payload (defence-in-depth) must also be HTML-
+        escaped on the data-confirm attribute. Django autoescape escapes
+        ``"`` to ``&quot;`` inside the attribute value, where the browser
+        cannot use it to step out.
+
+        The load-bearing check is that the raw HTML carries ``&quot;``
+        for every literal ``"`` in the username, so the attribute
+        cannot terminate early. We do not assert ``alert(1)`` is absent
+        from the form tag — it correctly remains in the attribute
+        value, where it is inert (it is rendered as part of the
+        ``confirm()`` message text, never evaluated).
+        """
+        # Replace the grant's user with a double-quote username user.
+        bad = User.objects.create_user(
+            username='x"); alert(1);//',
+            password="SafePass123!",
+        )
+        active_grant_for.user = bad
+        active_grant_for.save()
+        url = f"/resources/{active_grant_for.resource.pk}/"
+        response = admin_client.get(url)
+        content = response.content.decode()
+        revoke_url = f"/grants/{active_grant_for.pk}/revoke"
+        # The double-quote must appear as &quot; in the raw HTML — that
+        # is the load-bearing escape that prevents the attribute from
+        # terminating early.
+        revoke_form_match = re.search(
+            r'<form\b[^>]*\baction="' + re.escape(revoke_url) + r'"[^>]*>',
+            content,
+            re.DOTALL,
+        )
+        assert revoke_form_match is not None
+        assert "&quot;" in revoke_form_match.group(0), (
+            "double-quote not HTML-escaped in raw form HTML: "
+            f"{revoke_form_match.group(0)!r}"
+        )
+        # And the attribute must still be a single, well-formed attribute
+        # (no premature close-quote that would let later content leak
+        # into the surrounding tag). Assert there is exactly one closing
+        # ``">`` for the form tag.
+        assert revoke_form_match.group(0).rstrip().endswith(">"), (
+            "revoke form tag is not well-formed: "
+            f"{revoke_form_match.group(0)!r}"
+        )
+
+    def test_delegated_js_handles_data_confirm_forms(self):
+        """Static source check: ``core/static/core/js/delegated.js`` must
+        route forms with a ``data-confirm`` attribute through
+        ``window.confirm(form.dataset.confirm)`` and call
+        ``e.preventDefault()`` on cancel.
+
+        Without a JS runtime in the test suite, this is the next-best
+        guarantee that the delegated handler exists and reads the
+        attribute the template populates.
+        """
+        javascript = Path(
+            "core/static/core/js/delegated.js"
+        ).read_text()
+
+        # The data-confirm branch reads the attribute and calls confirm().
+        assert re.search(
+            r"form\.dataset\.confirm",
+            javascript,
+        ), "delegated.js must read form.dataset.confirm"
+        assert re.search(
+            r"window\.confirm\(\s*form\.dataset\.confirm\s*\)",
+            javascript,
+        ), "delegated.js must call window.confirm(form.dataset.confirm)"
+        # And it must short-circuit the submission on cancel.
+        assert re.search(
+            r"e\.preventDefault\(\)",
+            javascript,
+        ), "delegated.js must call e.preventDefault() to abort cancel"
+

--- a/tests/test_security_xss.py
+++ b/tests/test_security_xss.py
@@ -1,0 +1,187 @@
+"""Regression tests for the reflected XSS in
+``templates/registration/password_change_form.html`` (issue #55).
+
+The vulnerable template injected ``{{ request.user.username }}`` inside an
+inline ``<script>const USERNAME = "..."</script>`` block. Django's HTML
+autoescape only escapes HTML-significant characters (``"``, ``<``, ``>``,
+``&``); the browser HTML parser decodes ``&quot;`` back to ``"`` *before*
+the inline JavaScript parses, so a username such as
+``x"); alert(document.cookie);//`` could break out of the string literal and
+execute arbitrary code.
+
+The fix moves the username to a ``data-username="..."`` attribute on the
+new-password input (rendered via Django's widget-attr pipeline, so Django's
+autoescape escapes ``"`` to ``&quot;`` *inside the attribute value*, where
+the browser parser cannot use it to step out of the attribute). The
+inline ``<script>`` is removed; the password-strength JS reads the username
+from ``input.dataset.username``.
+
+The contract enforced by these tests is therefore:
+
+1. The response body MUST NOT contain an inline ``<script>`` block that
+   embeds the username as a JavaScript string literal.
+2. The response body MUST NOT contain the ``USERNAME = "`` substring at
+   all (broader guard against future re-introductions).
+3. A user with a malicious username MUST render the page with HTTP 200
+   and the literal payload MUST NOT appear as a JS-executable fragment.
+4. The new-password input MUST carry a ``data-username="..."`` attribute
+   and the value MUST be HTML-escaped (so ``"`` becomes ``&quot;``).
+5. The decoded ``data-username`` attribute MUST equal
+   ``user.get_username()`` for the authenticated user (round-trip
+   contract that the JS consumer depends on).
+"""
+
+from __future__ import annotations
+
+import html
+import re
+
+import pytest
+from django.contrib.auth.models import User
+from django.test import Client
+
+
+# A canonical JS-injection payload. Django's default
+# ``UnicodeUsernameValidator`` allows ASCII letters, digits, and ``@.+-_``
+# plus any non-ASCII printable character. ``;``, ``"``, ``(``, ``)``,
+# ``/``, ``*``, ``!`` are all permitted; we exploit that here.
+XSS_PAYLOAD = 'x"); alert(document.cookie);//'
+
+
+@pytest.fixture
+def xss_user(db):
+    """User whose username is a known JS-injection payload."""
+    User.objects.filter(username=XSS_PAYLOAD).delete()
+    return User.objects.create_user(
+        username=XSS_PAYLOAD,
+        password="SafePass123!",
+    )
+
+
+@pytest.fixture
+def xss_client(xss_user):
+    """Client logged in as the XSS-username user."""
+    client = Client()
+    client.login(username=xss_user.username, password="SafePass123!")
+    return client
+
+
+def _data_username_value(response_content: str) -> str:
+    """Extract the value of the ``data-username`` attribute on the
+    ``id_new_password1`` input, HTML-decoded.
+
+    Implemented with a stdlib-only regex (no BeautifulSoup dependency) to
+    stay within the project's test dependency set.
+    """
+    # Find the input element by id; capture the data-username attribute
+    # value. The attribute value may contain ``&quot;`` (HTML-escaped
+    # double-quote) which we decode back to a literal ``"``.
+    pattern = re.compile(
+        r'<input\b[^>]*\bid="id_new_password1"[^>]*>',
+        re.DOTALL,
+    )
+    match = pattern.search(response_content)
+    assert match is not None, (
+        "expected an <input id=\"id_new_password1\"> element in the response"
+    )
+    tag = match.group(0)
+    attr_match = re.search(
+        r'data-username="([^"]*)"',
+        tag,
+    )
+    assert attr_match is not None, (
+        f"expected data-username attribute on input tag: {tag!r}"
+    )
+    return html.unescape(attr_match.group(1))
+
+
+@pytest.mark.django_db
+class TestPasswordChangeXSSRegression:
+    """Regression contract for issue #55.
+
+    All five tests MUST fail on the pre-fix template and PASS on the
+    post-fix template (form class + view wiring + template removal +
+    JS dataset read).
+    """
+
+    def test_password_change_no_inline_script_block(
+        self, forced_password_client
+    ):
+        """REQ-SEC-1: response must not embed ``const USERNAME = "..."``."""
+        response = forced_password_client.get("/password/change/")
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert 'const USERNAME = "' not in content
+
+    def test_password_change_no_username_string_in_response(
+        self, forced_password_client
+    ):
+        """REQ-SEC-5: broader guard against any inline-script
+        re-introduction of the username-as-string-literal anti-pattern.
+        """
+        response = forced_password_client.get("/password/change/")
+        assert response.status_code == 200
+        content = response.content.decode()
+        # Broader check: any future inline-script reintroduction of the
+        # username-as-string-literal antipattern fails this assertion.
+        assert 'USERNAME = "' not in content
+
+    def test_password_change_handles_xss_username(self, xss_client):
+        """REQ-SEC-2 / REQ-SEC-5: a malicious username must render the
+        page with status 200 and must not appear as a JS string literal
+        inside any inline ``<script>`` block.
+
+        Django's HTML autoescape escapes ``"`` to ``&quot;`` even in the
+        vulnerable template, so the literal substring
+        ``x"); alert(document.cookie);//`` does NOT appear verbatim in
+        the raw HTML — the browser decodes ``&quot;`` back to ``"`` at
+        parse time, which is precisely what enables the XSS. The
+        load-bearing check is therefore that the malicious username is
+        NEVER interpolated into a ``<script>`` block as a JS string
+        literal: we look for ``const USERNAME = "<first-char>`` (the
+        opening of the dangerous pattern), which is present on the
+        vulnerable template and absent on the fixed template.
+        """
+        response = xss_client.get("/password/change/")
+        assert response.status_code == 200
+        content = response.content.decode()
+        # The dangerous JS-string-literal pattern must be absent. We
+        # match `const USERNAME = "<first-char>` rather than the full
+        # payload because the `"` is HTML-escaped in the vulnerable
+        # template.
+        assert 'const USERNAME = "x' not in content
+        # And no inline <script> block contains the malicious username.
+        for script_body in re.findall(
+            r"<script\b[^>]*>(.*?)</script>", content, re.DOTALL
+        ):
+            assert XSS_PAYLOAD not in script_body, (
+                "XSS payload found inside inline <script> block: "
+                f"{script_body!r}"
+            )
+
+    def test_password_change_input_has_data_username(self, xss_client):
+        """REQ-SEC-3: the new-password input must carry a
+        ``data-username="..."`` attribute, with ``"`` escaped to ``&quot;``.
+        """
+        response = xss_client.get("/password/change/")
+        assert response.status_code == 200
+        content = response.content.decode()
+        # The attribute must be present on the input.
+        assert "data-username=" in content
+        # The double-quote in the username must be HTML-escaped to
+        # ``&quot;`` (proof that the value is bound by the surrounding
+        # attribute quotes and cannot step out into JS context).
+        assert "&quot;" in content
+        # And no leftover JS-string-literal form of the username.
+        assert 'USERNAME = "x' not in content
+
+    def test_password_change_username_value_matches_user(
+        self, xss_client, xss_user
+    ):
+        """REQ-FUNC-5 / REQ-STRUCT-2: the decoded ``data-username``
+        attribute value MUST equal ``user.get_username()``.
+        """
+        response = xss_client.get("/password/change/")
+        assert response.status_code == 200
+        actual = _data_username_value(response.content.decode())
+        assert actual == xss_user.get_username()


### PR DESCRIPTION
## Summary

Closes the **reflected-XSS class** in AccessLedger (issue #55) where `{{ user.username }}` was interpolated into inline JavaScript. Two templates were vulnerable; both are fixed in this PR:

1. `templates/registration/password_change_form.html:104` — `request.user.username` was injected inside an inline `<script>const USERNAME = "..."</script>` block.
2. `core/templates/core/resource_detail.html:135` — `g.user.username` was injected inside an inline `onsubmit="return confirm('...@{{ g.user.username }}?')"` handler on the revoke form.

A malicious username like `x"); alert(document.cookie);//` (or the single-quote analogue `evil'); alert(1);//`) could break out of the JS string literal in either template and execute arbitrary code in any user's browser. For (1) the affected page is `/password/change/`, which is force-redirected after first login by `core/middleware.py`. For (2) the affected page is `/resources/<pk>/`, reachable by any admin viewing an active grant.

## Changes (password_change_form fix)

- New `CustomPasswordChangeForm(PasswordChangeForm)` in `core/forms.py` injects `data-username` on the new-password widget.
- `CustomPasswordChangeView` now uses `form_class = CustomPasswordChangeForm`.
- Inline `<script>const USERNAME = "..."</script>` removed from `password_change_form.html`.
- `password_change.js` reads the username from `input.dataset.username` instead of a global.
- `password_change.js` short-circuits the similarity hint when the username is empty (so empty-username users get a sane hint instead of "everything is similar to nothing").

## Changes (resource_detail revoke fix)

- `onsubmit="return confirm('…@{{ g.user.username }}?')"` on the revoke form replaced with `data-confirm="¿Revocar acceso de @{{ g.user.username }}?"`. The username is HTML-escaped inside the attribute.
- `core/static/core/js/delegated.js` got a delegated submit handler that intercepts any form with `data-confirm`, reads `form.dataset.confirm`, and calls `window.confirm(...)`. `confirm()` only displays text, so the autoescape property holds.
- A single-quote XSS payload (`evil'); alert(1);//`) renders with `&#x27;` inside the attribute, closing the JS-context break-out.

## Why this approach (not `|escapejs`)

`data-…="…"` is safe by construction: Django's HTML autoescape escapes `"` to `&quot;` *inside the attribute value*, where the browser parser cannot use it to step out into a JS context. The same property holds for the `data-confirm` attribute and `window.confirm()`. This also removes two inline-script / inline-handler anti-patterns (flagged as M-R6 in `docs/MEGA-ANALYSIS.md`) and unblocks future CSP rollout (issue #60).

## Code cleanup

- Removed the redundant `self.user = user` from `CustomPasswordChangeForm.__init__` — `super().__init__(user, ...)` already assigns it via `PasswordChangeForm`.
- Renamed the JS constant from `USERNAME` to `username` (lowercase per JS convention).

## Manual verification

1. Created user with username `evil"); alert(1);//` via `python manage.py shell`.
2. Logged in as that user, visited `/password/change/`.
3. Viewed source: no `<script>const USERNAME = ...</script>` block present.
4. Viewed source: input has `data-username="evil&quot;); alert(1);//"` (HTML-escaped).
5. Browser console: no errors.
6. Password similarity check still works (typing "evil12345" highlights "similar to username").
7. Created a second user with username `evil'); alert(1);//`, granted access to a resource, logged in as admin, opened the resource detail page.
8. Viewed source: revoke form has `data-confirm="¿Revocar acceso de @evil&#x27;); alert(1);//?"` — single quote HTML-escaped.
9. Viewed source: no `onsubmit=` handler on the revoke form.

## Test plan

- [x] `tests/test_security_xss.py` covers both XSS vectors:
  - 5 password_change_form regression tests
  - 2 password_change.js source-shape tests (empty-username short-circuit + non-empty similarity still runs)
  - 5 resource_detail revoke regression tests (no inline `onsubmit`, `data-confirm` present, decoded message matches username, double-quote payload HTML-escaped, delegated.js reads `data-confirm` and calls `window.confirm`)
- [x] `pytest tests/test_security_xss.py -v` → 12/12 pass.
- [x] All existing tests still pass (`pytest -q`).

## Commit map

- `test(security): add XSS regression cases for password_change_form` — RED tests.
- `feat(security): inject username via data-username widget attr` — form + view wiring.
- `refactor(js): read username from input.dataset in password_change.js` — JS consumer.
- `fix(security): remove inline USERNAME script from password_change_form.html` — exploit removal.
- `chore(security): verify password change XSS remediation` — verification evidence.
- `fix(security): complete XSS regression coverage` — additional edge cases.
- `fix(security): close XSS in resource_detail revoke handler` — second vector, delegated confirm handler.

Closes #55
